### PR TITLE
CDPT-1609 Display form data and improve upload validation

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -69,6 +69,7 @@ private
       :organisation_name,
       :requester_name,
       :letter_of_consent,
+      :letter_of_consent_id,
       :letter_of_consent_check,
       :requester_photo,
       :requester_photo_id,
@@ -76,7 +77,9 @@ private
       :requester_proof_of_address_id,
       :requester_id_check,
       :subject_photo,
+      :subject_photo_id,
       :subject_proof_of_address,
+      :subject_proof_of_address_id,
       :subject_id_check,
     )
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -27,9 +27,10 @@ class RequestsController < ApplicationController
 
   def update
     @form.assign_attributes(request_params)
+    @information_request.assign_attributes(@form.saveable_attributes)
+    set_form_attributes
 
     if @form.valid?
-      @information_request.assign_attributes(@form.saveable_attributes)
       session[:information_request] = @information_request.to_hash
       @form.back.nil? ? next_step : previous_step
     else
@@ -48,10 +49,14 @@ private
 
     @information_request = InformationRequest.new(session[:information_request])
     @form = "RequestForm::#{session[:current_step].underscore.camelize}".constantize.new
+    set_form_attributes
+    @form.request = @information_request
+  end
+
+  def set_form_attributes
     @form.attribute_names.each do |att|
       @form.send("#{att}=", @information_request.send(att))
     end
-    @form.request = @information_request
   end
 
   def request_params
@@ -66,7 +71,9 @@ private
       :letter_of_consent,
       :letter_of_consent_check,
       :requester_photo,
+      :requester_photo_id,
       :requester_proof_of_address,
+      :requester_proof_of_address_id,
       :requester_id_check,
       :subject_photo,
       :subject_proof_of_address,

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -27,7 +27,7 @@ class RequestsController < ApplicationController
     @form.assign_attributes(request_params)
 
     if @form.valid?
-      @information_request.assign_attributes(@form.attributes)
+      @information_request.assign_attributes(@form.saveable_attributes)
       session[:information_request] = @information_request.to_hash
       @form.back.nil? ? next_step : previous_step
     else
@@ -46,6 +46,9 @@ private
 
     @information_request = InformationRequest.new(session[:information_request])
     @form = "RequestForm::#{session[:current_step].underscore.camelize}".constantize.new
+    @form.attribute_names.each do |att|
+      @form.send("#{att}=", @information_request.send(att))
+    end
     @form.request = @information_request
   end
 

--- a/app/models/request_form/base.rb
+++ b/app/models/request_form/base.rb
@@ -13,5 +13,9 @@ module RequestForm
     def required?
       true
     end
+
+    def saveable_attributes
+      attributes
+    end
   end
 end

--- a/app/models/request_form/letter_of_consent.rb
+++ b/app/models/request_form/letter_of_consent.rb
@@ -1,12 +1,25 @@
 module RequestForm
   class LetterOfConsent < Base
     attribute :letter_of_consent
+    attribute :letter_of_consent_id
     attr_accessor :default
 
-    validates :letter_of_consent, presence: true, file_size: { max: 7.megabytes }
+    validates :letter_of_consent,
+              presence: true,
+              file_size: { max: 7.megabytes },
+              unless: -> { Attachment.exists?(letter_of_consent_id) }
 
     def required?
       !request.for_self?
+    end
+
+    def saveable_attributes
+      attrs = attributes.except("letter_of_consent_id")
+      if letter_of_consent.nil?
+        attrs.delete("letter_of_consent")
+      end
+
+      attrs
     end
   end
 end

--- a/app/models/request_form/letter_of_consent.rb
+++ b/app/models/request_form/letter_of_consent.rb
@@ -14,8 +14,9 @@ module RequestForm
     end
 
     def saveable_attributes
-      attrs = attributes.except("letter_of_consent_id")
+      attrs = attributes.clone
       attrs.delete("letter_of_consent") if letter_of_consent.nil?
+      attrs.delete("letter_of_consent_id") if letter_of_consent_id.nil?
       attrs
     end
   end

--- a/app/models/request_form/letter_of_consent.rb
+++ b/app/models/request_form/letter_of_consent.rb
@@ -15,8 +15,8 @@ module RequestForm
 
     def saveable_attributes
       attrs = attributes.clone
+      attrs.delete("letter_of_consent_id") if letter_of_consent_id.nil? || letter_of_consent.present?
       attrs.delete("letter_of_consent") if letter_of_consent.nil?
-      attrs.delete("letter_of_consent_id") if letter_of_consent_id.nil?
       attrs
     end
   end

--- a/app/models/request_form/letter_of_consent.rb
+++ b/app/models/request_form/letter_of_consent.rb
@@ -15,10 +15,7 @@ module RequestForm
 
     def saveable_attributes
       attrs = attributes.except("letter_of_consent_id")
-      if letter_of_consent.nil?
-        attrs.delete("letter_of_consent")
-      end
-
+      attrs.delete("letter_of_consent") if letter_of_consent.nil?
       attrs
     end
   end

--- a/app/models/request_form/requester_id.rb
+++ b/app/models/request_form/requester_id.rb
@@ -20,7 +20,9 @@ module RequestForm
     end
 
     def saveable_attributes
-      attrs = attributes.except("requester_photo_id", "requester_proof_of_address_id")
+      attrs = attributes.clone
+      attrs.delete("requester_photo_id") if requester_photo_id.nil? || requester_photo.present?
+      attrs.delete("requester_proof_of_address_id") if requester_proof_of_address_id.nil? || requester_proof_of_address.present?
       attrs.delete("requester_photo") if requester_photo.nil?
       attrs.delete("requester_proof_of_address") if requester_proof_of_address.nil?
       attrs

--- a/app/models/request_form/requester_id.rb
+++ b/app/models/request_form/requester_id.rb
@@ -1,15 +1,29 @@
 module RequestForm
   class RequesterId < Base
     attribute :requester_photo
+    attribute :requester_photo_id
     attribute :requester_proof_of_address
-
+    attribute :requester_proof_of_address_id
     attr_accessor :default
 
-    validates :requester_photo, presence: true, file_size: { max: 7.megabytes }
-    validates :requester_proof_of_address, presence: true, file_size: { max: 7.megabytes }
+    validates :requester_photo,
+              presence: true,
+              file_size: { max: 7.megabytes },
+              unless: -> { Attachment.exists?(requester_photo_id) }
+    validates :requester_proof_of_address,
+              presence: true,
+              file_size: { max: 7.megabytes },
+              unless: -> { Attachment.exists?(requester_proof_of_address_id) }
 
     def required?
       !request.for_self? && !request.solicitor_request?
+    end
+
+    def saveable_attributes
+      attrs = attributes.except("requester_photo_id", "requester_proof_of_address_id")
+      attrs.delete("requester_photo") if requester_photo.nil?
+      attrs.delete("requester_proof_of_address") if requester_proof_of_address.nil?
+      attrs
     end
   end
 end

--- a/app/models/request_form/subject_id.rb
+++ b/app/models/request_form/subject_id.rb
@@ -1,15 +1,29 @@
 module RequestForm
   class SubjectId < Base
     attribute :subject_photo
+    attribute :subject_photo_id
     attribute :subject_proof_of_address
-
+    attribute :subject_proof_of_address_id
     attr_accessor :default
 
-    validates :subject_photo, presence: true, file_size: { max: 7.megabytes }
-    validates :subject_proof_of_address, presence: true, file_size: { max: 7.megabytes }
+    validates :subject_photo,
+              presence: true,
+              file_size: { max: 7.megabytes },
+              unless: -> { Attachment.exists?(subject_photo_id) }
+    validates :subject_proof_of_address,
+              presence: true,
+              file_size: { max: 7.megabytes },
+              unless: -> { Attachment.exists?(subject_proof_of_address_id) }
 
     def required?
       !request.solicitor_request?
+    end
+
+    def saveable_attributes
+      attrs = attributes.except("subject_photo_id", "subject_proof_of_address_id")
+      attrs.delete("subject_photo") if subject_photo.nil?
+      attrs.delete("subject_proof_of_address") if subject_proof_of_address.nil?
+      attrs
     end
   end
 end

--- a/app/models/request_form/subject_id.rb
+++ b/app/models/request_form/subject_id.rb
@@ -20,7 +20,9 @@ module RequestForm
     end
 
     def saveable_attributes
-      attrs = attributes.except("subject_photo_id", "subject_proof_of_address_id")
+      attrs = attributes.clone
+      attrs.delete("subject_photo_id") if subject_photo_id.nil? || subject_photo.present?
+      attrs.delete("subject_proof_of_address_id") if subject_proof_of_address_id.nil? || subject_proof_of_address.present?
       attrs.delete("subject_photo") if subject_photo.nil?
       attrs.delete("subject_proof_of_address") if subject_proof_of_address.nil?
       attrs

--- a/app/views/requests/_letter_of_consent.html.erb
+++ b/app/views/requests/_letter_of_consent.html.erb
@@ -1,2 +1,3 @@
 <%= f.govuk_file_field :letter_of_consent, label: nil %>
+<%= f.hidden_field :letter_of_consent_id %>
 <%= f.hidden_field :default %>

--- a/app/views/requests/_requester_id.html.erb
+++ b/app/views/requests/_requester_id.html.erb
@@ -3,5 +3,7 @@
 <p class="govuk-body">These can be a photograph, scan or photocopy of the original document.
 
 <%= f.govuk_file_field :requester_photo, label: { size: "m" } %>
+<%= f.hidden_field :requester_photo_id %>
 <%= f.govuk_file_field :requester_proof_of_address, label: { size: "m" }  %>
+<%= f.hidden_field :requester_proof_of_address_id %>
 <%= f.hidden_field :default %>

--- a/app/views/requests/_subject_id.html.erb
+++ b/app/views/requests/_subject_id.html.erb
@@ -3,5 +3,7 @@
 <p class="govuk-body">These can be a photograph, scan or photocopy of the original document.
 
 <%= f.govuk_file_field :subject_photo, label: { size: "m" } %>
+<%= f.hidden_field :subject_photo_id %>
 <%= f.govuk_file_field :subject_proof_of_address, label: { size: "m" }  %>
+<%= f.hidden_field :subject_proof_of_address_id %>
 <%= f.hidden_field :default %>

--- a/spec/models/request_form/letter_of_consent_check_spec.rb
+++ b/spec/models/request_form/letter_of_consent_check_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::LetterOfConsentCheck, type: :model do
   it_behaves_like "question when requester is not the subject"
+  it_behaves_like "question with standard saveable attributes"
 
   describe "validation" do
     subject(:form_object) { described_class.new(letter_of_consent_check: check) }

--- a/spec/models/request_form/letter_of_consent_spec.rb
+++ b/spec/models/request_form/letter_of_consent_spec.rb
@@ -1,39 +1,6 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::LetterOfConsent, type: :model do
-  it_behaves_like "file upload with max filesize validation", :letter_of_consent
+  it_behaves_like "file upload", :letter_of_consent
   it_behaves_like "question when requester is not the subject"
-
-  describe "validation" do
-    context "when file was previously uploaded" do
-      subject(:form_object) { described_class.new(letter_of_consent_id: upload.id) }
-
-      let(:upload) { create(:attachment) }
-
-      it "is valid" do
-        expect(form_object).to be_valid
-      end
-    end
-  end
-
-  describe "#saveable_attributes" do
-    subject(:form_object) { described_class.new }
-
-    it "does not include letter_of_consent_id" do
-      expect(form_object.saveable_attributes.keys).not_to include "letter_of_consent_id"
-    end
-
-    context "when letter_of_consent is nil" do
-      it "does not include letter_of_consent" do
-        expect(form_object.saveable_attributes.keys).not_to include "letter_of_consent"
-      end
-    end
-
-    context "when letter_of_consent is present" do
-      it "includes letter_of_consent" do
-        form_object.letter_of_consent = "exists"
-        expect(form_object.saveable_attributes.keys).to include "letter_of_consent"
-      end
-    end
-  end
 end

--- a/spec/models/request_form/letter_of_consent_spec.rb
+++ b/spec/models/request_form/letter_of_consent_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe RequestForm::LetterOfConsent, type: :model do
         expect(form_object.errors.first.message).to eq "The selected file must be smaller than 7 MB"
       end
     end
+
+    context "when file was previously uploaded" do
+      subject(:form_object) { described_class.new(letter_of_consent_id: upload.id) }
+
+      let(:upload) { create(:attachment) }
+
+      it "is valid" do
+        expect(form_object).to be_valid
+      end
+    end
   end
 
   describe "#required?" do

--- a/spec/models/request_form/letter_of_consent_spec.rb
+++ b/spec/models/request_form/letter_of_consent_spec.rb
@@ -15,4 +15,25 @@ RSpec.describe RequestForm::LetterOfConsent, type: :model do
       end
     end
   end
+
+  describe "#saveable_attributes" do
+    subject(:form_object) { described_class.new }
+
+    it "does not include letter_of_consent_id" do
+      expect(form_object.saveable_attributes.keys).not_to include "letter_of_consent_id"
+    end
+
+    context "when letter_of_consent is nil" do
+      it "does not include letter_of_consent" do
+        expect(form_object.saveable_attributes.keys).not_to include "letter_of_consent"
+      end
+    end
+
+    context "when letter_of_consent is present" do
+      it "includes letter_of_consent" do
+        form_object.letter_of_consent = "exists"
+        expect(form_object.saveable_attributes.keys).to include "letter_of_consent"
+      end
+    end
+  end
 end

--- a/spec/models/request_form/letter_of_consent_spec.rb
+++ b/spec/models/request_form/letter_of_consent_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::LetterOfConsent, type: :model do
-  it_behaves_like "file upload", :letter_of_consent
   it_behaves_like "question when requester is not the subject"
+  it_behaves_like "file upload", :letter_of_consent
 end

--- a/spec/models/request_form/requester_details_spec.rb
+++ b/spec/models/request_form/requester_details_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::RequesterDetails, type: :model do
   it_behaves_like "question for friend or family of subject"
+  it_behaves_like "question with standard saveable attributes"
 
   it { is_expected.to validate_presence_of(:requester_name) }
 end

--- a/spec/models/request_form/requester_id_check_spec.rb
+++ b/spec/models/request_form/requester_id_check_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::RequesterIdCheck, type: :model do
   it_behaves_like "question for friend or family of subject"
+  it_behaves_like "question with standard saveable attributes"
 
   describe "validation" do
     subject(:form_object) { described_class.new(requester_id_check: check) }

--- a/spec/models/request_form/requester_id_spec.rb
+++ b/spec/models/request_form/requester_id_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe RequestForm::RequesterId, type: :model do
   it_behaves_like "question for friend or family of subject"
-  it_behaves_like "file upload with max filesize validation", :requester_photo
-  it_behaves_like "file upload with max filesize validation", :requester_proof_of_address
+  it_behaves_like "file upload", :requester_photo
+  it_behaves_like "file upload", :requester_proof_of_address
 end

--- a/spec/models/request_form/solicitor_details_spec.rb
+++ b/spec/models/request_form/solicitor_details_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::SolicitorDetails, type: :model do
   it_behaves_like "question for solicitor"
+  it_behaves_like "question with standard saveable attributes"
 
   it { is_expected.to validate_presence_of(:organisation_name) }
 end

--- a/spec/models/request_form/subject_date_of_birth_spec.rb
+++ b/spec/models/request_form/subject_date_of_birth_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::SubjectDateOfBirth, type: :model do
+  it_behaves_like "question for everyone"
   it_behaves_like "validated attribute with custom message", :date_of_birth, Date.new
-
-  describe "#required?" do
-    it { is_expected.to be_required }
-  end
+  it_behaves_like "question with standard saveable attributes"
 end

--- a/spec/models/request_form/subject_id_check_spec.rb
+++ b/spec/models/request_form/subject_id_check_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::SubjectIdCheck, type: :model do
   it_behaves_like "question when requester is not a solicitor"
+  it_behaves_like "question with standard saveable attributes"
 
   describe "validation" do
     subject(:form_object) { described_class.new(subject_id_check: check) }

--- a/spec/models/request_form/subject_id_spec.rb
+++ b/spec/models/request_form/subject_id_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe RequestForm::SubjectId, type: :model do
   it_behaves_like "question when requester is not a solicitor"
-  it_behaves_like "file upload with max filesize validation", :subject_photo
-  it_behaves_like "file upload with max filesize validation", :subject_proof_of_address
+  it_behaves_like "file upload", :subject_photo
+  it_behaves_like "file upload", :subject_proof_of_address
 end

--- a/spec/models/request_form/subject_name_spec.rb
+++ b/spec/models/request_form/subject_name_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::SubjectName, type: :model do
+  it_behaves_like "question for everyone"
   it_behaves_like "validated attribute with custom message", :full_name, "a name"
-
-  describe "#required?" do
-    it { is_expected.to be_required }
-  end
+  it_behaves_like "question with standard saveable attributes"
 end

--- a/spec/models/request_form/subject_relationship_spec.rb
+++ b/spec/models/request_form/subject_relationship_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RequestForm::SubjectRelationship, type: :model do
   it_behaves_like "question when requester is not the subject"
+  it_behaves_like "question with standard saveable attributes"
 
   it { is_expected.to validate_presence_of(:relationship) }
 end

--- a/spec/models/request_form/subject_spec.rb
+++ b/spec/models/request_form/subject_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::Subject, type: :model do
-  it { is_expected.to validate_presence_of(:subject) }
+  it_behaves_like "question for everyone"
+  it_behaves_like "question with standard saveable attributes"
 
-  describe "#required?" do
-    it { is_expected.to be_required }
-  end
+  it { is_expected.to validate_presence_of(:subject) }
 end

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe "Requester", type: :request do
 
   describe "/letter-of-consent" do
     let(:current_step) { "letter-of-consent" }
+    let(:next_step) { "/letter-of-consent-check" }
 
     context "when session not in progress" do
       it "redirects to the homepage" do
@@ -128,7 +129,6 @@ RSpec.describe "Requester", type: :request do
     context "when session in progress" do
       let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
       let(:previous_step) { "/requester-details" }
-      let(:next_step) { "/letter-of-consent-check" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
 
@@ -168,6 +168,21 @@ RSpec.describe "Requester", type: :request do
           get("/request/back")
           expect(response).to redirect_to(previous_step)
         end
+      end
+    end
+
+    context "when returning to page" do
+      let(:letter_of_consent) { create(:attachment) }
+      let(:information_request) { build(:information_request_for_other, letter_of_consent_id: letter_of_consent.id) }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step:, history: [])
+        get "/#{current_step}"
+      end
+
+      it "doesn't require repeat upload" do
+        patch "/request", params: { request_form: { letter_of_consent_id: letter_of_consent.id } }
+        expect(response).to redirect_to(next_step)
       end
     end
   end
@@ -233,6 +248,7 @@ RSpec.describe "Requester", type: :request do
 
   describe "/requester-id" do
     let(:current_step) { "requester-id" }
+    let(:next_step) { "/requester-id-check" }
 
     context "when session not in progress" do
       it "redirects to the homepage" do
@@ -244,7 +260,6 @@ RSpec.describe "Requester", type: :request do
     context "when session in progress" do
       let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
       let(:previous_step) { "/letter-of-consent" }
-      let(:next_step) { "/requester-id-check" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
 
@@ -286,6 +301,22 @@ RSpec.describe "Requester", type: :request do
           get("/request/back")
           expect(response).to redirect_to(previous_step)
         end
+      end
+    end
+
+    context "when returning to page" do
+      let(:photo_upload) { create(:attachment) }
+      let(:address_upload) { create(:attachment) }
+      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other", requester_photo_id: photo_upload.id, requester_proof_of_address_id: address_upload.id) }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step:, history: [])
+        get "/#{current_step}"
+      end
+
+      it "doesn't require repeat upload" do
+        patch "/request", params: { request_form: { requester_photo_id: photo_upload.id, requester_proof_of_address_id: address_upload.id } }
+        expect(response).to redirect_to(next_step)
       end
     end
   end

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -291,6 +291,7 @@ RSpec.describe "Subject", type: :request do
 
   describe "/subject-id" do
     let(:current_step) { "subject-id" }
+    let(:next_step) { "/subject-id-check" }
 
     context "when session not in progress" do
       it "redirects to the homepage" do
@@ -302,7 +303,6 @@ RSpec.describe "Subject", type: :request do
     context "when session in progress" do
       let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
       let(:previous_step) { "/requester-id" }
-      let(:next_step) { "/subject-id-check" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
 
@@ -344,6 +344,22 @@ RSpec.describe "Subject", type: :request do
           get("/request/back")
           expect(response).to redirect_to(previous_step)
         end
+      end
+    end
+
+    context "when returning to page" do
+      let(:photo_upload) { create(:attachment) }
+      let(:address_upload) { create(:attachment) }
+      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other", subject_photo_id: photo_upload.id, subject_proof_of_address_id: address_upload.id) }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step:, history: [])
+        get "/#{current_step}"
+      end
+
+      it "doesn't require repeat upload" do
+        patch "/request", params: { request_form: { subject_photo_id: photo_upload.id, subject_proof_of_address_id: address_upload.id } }
+        expect(response).to redirect_to(next_step)
       end
     end
   end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -78,6 +78,7 @@ RSpec.shared_examples("file upload") do |attribute|
       context "when file is being uploaded" do
         it "includes file, but no ID" do
           form_object.send("#{attribute}=", "exists")
+          form_object.send("#{attribute}_id=", 1)
           expect(form_object.saveable_attributes.keys).to include attribute.to_s
           expect(form_object.saveable_attributes.keys).not_to include "#{attribute}_id"
         end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -60,20 +60,26 @@ RSpec.shared_examples("file upload") do |attribute|
     describe "#saveable_attributes" do
       subject(:form_object) { described_class.new }
 
-      it "does not include the upload id" do
-        expect(form_object.saveable_attributes.keys).not_to include "#{attribute}_id"
-      end
-
-      context "when file is not uploaded" do
-        it "does not include upload" do
+      context "when file was previously uploaded" do
+        it "includes the upload id only" do
+          form_object.send("#{attribute}_id=", 1)
+          expect(form_object.saveable_attributes.keys).to include "#{attribute}_id"
           expect(form_object.saveable_attributes.keys).not_to include attribute.to_s
         end
       end
 
-      context "when file is uploaded" do
-        it "includes upload" do
+      context "when there is no upload" do
+        it "does not include any upload attribute" do
+          expect(form_object.saveable_attributes.keys).not_to include attribute.to_s
+          expect(form_object.saveable_attributes.keys).not_to include "#{attribute}_id"
+        end
+      end
+
+      context "when file is being uploaded" do
+        it "includes file, but no ID" do
           form_object.send("#{attribute}=", "exists")
           expect(form_object.saveable_attributes.keys).to include attribute.to_s
+          expect(form_object.saveable_attributes.keys).not_to include "#{attribute}_id"
         end
       end
     end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -80,6 +80,12 @@ RSpec.shared_examples("file upload") do |attribute|
   end
 end
 
+RSpec.shared_examples("question for everyone") do
+  describe "#required?" do
+    it { is_expected.to be_required }
+  end
+end
+
 RSpec.shared_examples("question when requester is not the subject") do
   describe "#required?" do
     subject(:form_object) { described_class.new }
@@ -210,6 +216,16 @@ RSpec.shared_examples("question when requester is not a solicitor") do
           expect(form_object).to be_required
         end
       end
+    end
+  end
+end
+
+RSpec.shared_examples("question with standard saveable attributes") do
+  subject(:form_object) { described_class.new }
+
+  describe "#saveable_attributes" do
+    it "matches attributes" do
+      expect(form_object.saveable_attributes).to eq form_object.attributes
     end
   end
 end


### PR DESCRIPTION
When going back to a previous step, show attributes previously entered.
Also handles file validation better so previously uploaded files are not overwritten.