### PR TITLE
Move upload requester ID before Letter of Consent

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -6,10 +6,10 @@ class RequestsController < ApplicationController
     subject-relationship
     solicitor-details
     requester-details
-    letter-of-consent
-    letter-of-consent-check
     requester-id
     requester-id-check
+    letter-of-consent
+    letter-of-consent-check
     subject-id
     subject-id-check
   ].freeze

--- a/app/views/requests/_subject_id.html.erb
+++ b/app/views/requests/_subject_id.html.erb
@@ -1,9 +1,13 @@
+<% content_for :title do %>
+  <%= t("request_form.#{@form.name}.#{@information_request.subject}") %>
+<% end %>
+
 <p class="govuk-body-l">You must upload both proof of ID and address.
 
 <p class="govuk-body">These can be a photograph, scan or photocopy of the original document.
 
-<%= f.govuk_file_field :subject_photo, label: { size: "m" } %>
+<%= f.govuk_file_field :subject_photo, label: { size: "m" }, hint: { text: t("helpers.hint.request_form.subject_photo.#{@information_request.subject}") } %>
 <%= f.hidden_field :subject_photo_id %>
-<%= f.govuk_file_field :subject_proof_of_address, label: { size: "m" }  %>
+<%= f.govuk_file_field :subject_proof_of_address, label: { size: "m" }, hint: { text: t("helpers.hint.request_form.subject_proof_of_address.#{@information_request.subject}") } %>
 <%= f.hidden_field :subject_proof_of_address_id %>
 <%= f.hidden_field :default %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,8 +72,12 @@ en:
         letter_of_consent: "This must be signed by the person you are requesting information about and dated within the last 6 months. There is no official template. Maximum size: 7MB"
         requester_photo: "For example, a copy of your driving licence or passport. Maximum size: 7MB per file"
         requester_proof_of_address: "For example an electricity or council tax bill in your name and it must be dated within the last 6 months. Maximum file size 7MB"
-        subject_photo: "For example, a copy of their driving licence or passport. Maximum size: 7MB per file"
-        subject_proof_of_address: "For example an electricity or council tax bill in their name and it must be dated within the last 6 months. Maximum file size 7MB"
+        subject_photo:
+          other: "For example, a copy of their driving licence or passport. Maximum size: 7MB per file"
+          self: "For example, a copy of your driving licence or passport. Maximum size: 7MB per file"
+        subject_proof_of_address:
+          other: "For example an electricity or council tax bill in their name and it must be dated within the last 6 months. Maximum file size 7MB"
+          self: "For example an electricity or council tax bill in your name and it must be dated within the last 6 months. Maximum file size 7MB"
 
   request_form:
     letter_of_consent: Upload a letter of consent
@@ -86,11 +90,13 @@ en:
     subject_date_of_birth:
         other: What is their date of birth?
         self: What is your date of birth?
-    subject_id: Upload their ID
+    subject_id:
+      other: Upload their ID
+      self: Upload your ID
     subject_id_check: Check your upload
     subject_name:
-      self: What is your name?
       other: What is their name?
+      self: What is your name?
     subject_relationship: What is your relationship to them?
   service:
     name: "Request personal information"

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Requester", type: :request do
     context "when session in progress" do
       let(:information_request) { build(:information_request_for_other) }
       let(:previous_step) { "/subject-relationship" }
-      let(:next_step) { "/letter-of-consent" }
+      let(:next_step) { "/requester-id" }
       let(:valid_data) { "requester name" }
       let(:invalid_data) { "" }
 
@@ -127,7 +127,7 @@ RSpec.describe "Requester", type: :request do
     end
 
     context "when session in progress" do
-      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
+      let(:information_request) { build(:information_request_by_friend) }
       let(:previous_step) { "/requester-details" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
@@ -200,7 +200,7 @@ RSpec.describe "Requester", type: :request do
     context "when session in progress" do
       let(:information_request) { build(:information_request_with_consent) }
       let(:previous_step) { "/letter-of-consent" }
-      let(:next_step) { "/requester-id" }
+      let(:next_step) { "/subject-id" }
       let(:valid_data) { "yes" }
       let(:invalid_data) { "" }
 
@@ -258,7 +258,7 @@ RSpec.describe "Requester", type: :request do
     end
 
     context "when session in progress" do
-      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
+      let(:information_request) { build(:information_request_by_friend) }
       let(:previous_step) { "/letter-of-consent" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
@@ -307,7 +307,7 @@ RSpec.describe "Requester", type: :request do
     context "when returning to page" do
       let(:photo_upload) { create(:attachment) }
       let(:address_upload) { create(:attachment) }
-      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other", requester_photo_id: photo_upload.id, requester_proof_of_address_id: address_upload.id) }
+      let(:information_request) { build(:information_request_by_friend, requester_photo_id: photo_upload.id, requester_proof_of_address_id: address_upload.id) }
 
       before do
         set_session(information_request: information_request.to_hash, current_step:, history: [])
@@ -334,7 +334,7 @@ RSpec.describe "Requester", type: :request do
     context "when session in progress" do
       let(:information_request) { build(:information_request_with_requester_id) }
       let(:previous_step) { "/requester-id" }
-      let(:next_step) { "/subject-id" }
+      let(:next_step) { "/letter-of-consent" }
       let(:valid_data) { "yes" }
       let(:invalid_data) { "" }
 

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "Subject", type: :request do
     end
 
     context "when session in progress" do
-      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other") }
+      let(:information_request) { build(:information_request_by_friend) }
       let(:previous_step) { "/requester-id" }
       let(:valid_data) { fixture_file_upload("file.jpg") }
       let(:invalid_data) { nil }
@@ -311,9 +311,24 @@ RSpec.describe "Subject", type: :request do
         get "/#{current_step}"
       end
 
-      it "renders the subject ID page" do
-        expect(response).to render_template(:show)
-        expect(response.body).to include("Upload their ID")
+      context "when requesting data for someone else" do
+        it "renders the subject ID page" do
+          expect(response).to render_template(:show)
+          expect(response.body).to include("Upload their ID")
+          expect(response.body).to include("For example, a copy of their driving licence or passport")
+          expect(response.body).to include("For example an electricity or council tax bill in their name")
+        end
+      end
+
+      context "when requesting data for self" do
+        let(:information_request) { build(:information_request_for_self) }
+
+        it "renders the subject ID page" do
+          expect(response).to render_template(:show)
+          expect(response.body).to include("Upload your ID")
+          expect(response.body).to include("For example, a copy of your driving licence or passport")
+          expect(response.body).to include("For example an electricity or council tax bill in your name")
+        end
       end
 
       context "when submitting form with invalid data" do
@@ -350,7 +365,7 @@ RSpec.describe "Subject", type: :request do
     context "when returning to page" do
       let(:photo_upload) { create(:attachment) }
       let(:address_upload) { create(:attachment) }
-      let(:information_request) { InformationRequest.new(subject: "other", relationship: "other", subject_photo_id: photo_upload.id, subject_proof_of_address_id: address_upload.id) }
+      let(:information_request) { build(:information_request_by_friend, subject_photo_id: photo_upload.id, subject_proof_of_address_id: address_upload.id) }
 
       before do
         set_session(information_request: information_request.to_hash, current_step:, history: [])


### PR DESCRIPTION
Also adds translations for when the subject is uploading their own ID.