### PR TITLE
Fix large file validation

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -55,7 +55,7 @@ private
   end
 
   def set_form_attributes
-    @form.attribute_names.each do |att|
+    @form.updateable_attributes.each_key do |att|
       @form.send("#{att}=", @information_request.send(att))
     end
   end

--- a/app/models/request_form/base.rb
+++ b/app/models/request_form/base.rb
@@ -17,5 +17,9 @@ module RequestForm
     def saveable_attributes
       attributes
     end
+
+    def updateable_attributes
+      attributes
+    end
   end
 end

--- a/app/models/request_form/letter_of_consent.rb
+++ b/app/models/request_form/letter_of_consent.rb
@@ -17,5 +17,9 @@ module RequestForm
       attrs.delete("letter_of_consent") if letter_of_consent.nil?
       attrs
     end
+
+    def updateable_attributes
+      attributes.except("letter_of_consent")
+    end
   end
 end

--- a/app/models/request_form/requester_id.rb
+++ b/app/models/request_form/requester_id.rb
@@ -23,5 +23,9 @@ module RequestForm
       attrs.delete("requester_proof_of_address") if requester_proof_of_address.nil?
       attrs
     end
+
+    def updateable_attributes
+      attributes.except("requester_photo", "requester_proof_of_address")
+    end
   end
 end

--- a/app/models/request_form/subject_id.rb
+++ b/app/models/request_form/subject_id.rb
@@ -23,5 +23,9 @@ module RequestForm
       attrs.delete("subject_proof_of_address") if subject_proof_of_address.nil?
       attrs
     end
+
+    def updateable_attributes
+      attributes.except("subject_photo", "subject_proof_of_address")
+    end
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -87,6 +87,14 @@ RSpec.shared_examples("file upload") do |attribute|
         end
       end
     end
+
+    describe "#updateable_attributes" do
+      subject(:form_object) { described_class.new }
+
+      it "excludes file objects" do
+        expect(form_object.updateable_attributes.keys).not_to include attribute.to_s
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The file was being overwritten on the form object before validation. The `updateable_attributes` method will stop that happening.