### PR TITLE
Set correct environment

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+Sentry.init do |config|
+  config.dsn = ENV["SENTRY_DSN"]
+  config.breadcrumbs_logger = [:active_support_logger]
+end

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -5,6 +5,6 @@ metadata:
   namespace: request-personal-information-staging
 data:
   RAILS_ENV: production
-  SENTRY_ENVIRONMENT: staging
+  SENTRY_CURRENT_ENV: staging
   RAILS_SERVE_STATIC_FILES: enabled
   API_URL: "https://qa.track-a-query.service.justice.gov.uk/api/rpi/v2"


### PR DESCRIPTION
Environment is being set as production in the staging environment. This sets `SENTRY_CURRENT_ENV` to be used instead.