### PR TITLE
Fix optional usage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,7 +225,7 @@ en:
       self: Which prison were you most recently in?
     prison_number:
       other: What is their prison number?
-      self: What was your prison number (optional)?
+      self: What was your prison number? (optional)
     probation_dates: What dates do you want this information from? (optional)
     probation_information: What probation service information do you want?
     probation_location:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,17 +159,17 @@ en:
         upcoming_court_case_text: Can you provide more details?
     legend:
       request_form:
-        form_laa_date_from: Enter a date this information should start from (optional)
-        form_laa_date_to: Enter a date this information should go to (optional)
+        form_laa_date_from: Enter a date this information should start from
+        form_laa_date_to: Enter a date this information should go to
         letter_of_consent_check: Is this upload correct?
-        form_moj_other_date_from: Enter a date this information should start from (optional)
-        form_moj_other_date_to: Enter a date this information should go to (optional)
-        form_opg_date_from: Enter a date this information should start from (optional)
-        form_opg_date_to: Enter a date this information should go to (optional)
-        form_prison_date_from: Enter a date this information should start from (optional)
-        form_prison_date_to: Enter a date this information should go to (optional)
-        form_probation_date_from: Enter a date this information should start from (optional)
-        form_probation_date_to: Enter a date this information should go to (optional)
+        form_moj_other_date_from: Enter a date this information should start from
+        form_moj_other_date_to: Enter a date this information should go to
+        form_opg_date_from: Enter a date this information should start from
+        form_opg_date_to: Enter a date this information should go to
+        form_prison_date_from: Enter a date this information should start from
+        form_prison_date_to: Enter a date this information should go to
+        form_probation_date_from: Enter a date this information should start from
+        form_probation_date_to: Enter a date this information should go to
         requester_id_check: Are these uploads correct?
         subject_id_check: Are these uploads correct?
     hint:

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe NotifyMailer, type: :mailer do
     it "renders details of information required" do
       expect(mail.body.encoded).to match("## HM Prison Service")
       expect(mail.body.encoded).to match(/Which prison were you most recently in\?:\s+HMP Fosse Way/)
-      expect(mail.body.encoded).to match(/What was your prison number \(optional\)\?:\s+ABC123/)
+      expect(mail.body.encoded).to match(/What was your prison number\? \(optional\):\s+ABC123/)
       expect(mail.body.encoded).to match(/What prison service information do you want\?:\s+NOMIS Records/)
-      expect(mail.body.encoded).to match(/Enter a date this information should start from \(optional\):\s+2010-03-10/)
-      expect(mail.body.encoded).to match(/Enter a date this information should go to \(optional\):\s+2012-05-20/)
+      expect(mail.body.encoded).to match(/Enter a date this information should start from:\s+2010-03-10/)
+      expect(mail.body.encoded).to match(/Enter a date this information should go to:\s+2012-05-20/)
     end
 
     it "renders contact details" do

--- a/spec/models/information_request_summary_spec.rb
+++ b/spec/models/information_request_summary_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe InformationRequestSummary, type: :model do
         end
 
         it "returns where the subject's prison number" do
-          expect(summary.prison[1]).to include({ key: { text: "What was your prison number (optional)?" } })
+          expect(summary.prison[1]).to include({ key: { text: "What was your prison number? (optional)" } })
           expect(summary.prison[1]).to include({ value: { text: "ABC123" } })
         end
       end
@@ -221,9 +221,9 @@ RSpec.describe InformationRequestSummary, type: :model do
       end
 
       it "returns dates information is required for" do
-        expect(summary.prison[4]).to include({ key: { text: "Enter a date this information should start from (optional)" } })
+        expect(summary.prison[4]).to include({ key: { text: "Enter a date this information should start from" } })
         expect(summary.prison[4]).to include({ value: { text: "2010-03-10" } })
-        expect(summary.prison[5]).to include({ key: { text: "Enter a date this information should go to (optional)" } })
+        expect(summary.prison[5]).to include({ key: { text: "Enter a date this information should go to" } })
         expect(summary.prison[5]).to include({ value: { text: "2012-05-20" } })
       end
 
@@ -273,9 +273,9 @@ RSpec.describe InformationRequestSummary, type: :model do
       end
 
       it "returns dates information is required for" do
-        expect(summary.probation[2]).to include({ key: { text: "Enter a date this information should start from (optional)" } })
+        expect(summary.probation[2]).to include({ key: { text: "Enter a date this information should start from" } })
         expect(summary.probation[2]).to include({ value: { text: "2014-01-12" } })
-        expect(summary.probation[3]).to include({ key: { text: "Enter a date this information should go to (optional)" } })
+        expect(summary.probation[3]).to include({ key: { text: "Enter a date this information should go to" } })
         expect(summary.probation[3]).to include({ value: { text: "2020-11-02" } })
       end
 
@@ -310,9 +310,9 @@ RSpec.describe InformationRequestSummary, type: :model do
       end
 
       it "returns dates information is required for" do
-        expect(summary.laa[1]).to include({ key: { text: "Enter a date this information should start from (optional)" } })
+        expect(summary.laa[1]).to include({ key: { text: "Enter a date this information should start from" } })
         expect(summary.laa[1]).to include({ value: { text: "2015-01-20" } })
-        expect(summary.laa[2]).to include({ key: { text: "Enter a date this information should go to (optional)" } })
+        expect(summary.laa[2]).to include({ key: { text: "Enter a date this information should go to" } })
         expect(summary.laa[2]).to include({ value: { text: "2016-03-01" } })
       end
     end
@@ -336,9 +336,9 @@ RSpec.describe InformationRequestSummary, type: :model do
       end
 
       it "returns dates information is required for" do
-        expect(summary.opg[1]).to include({ key: { text: "Enter a date this information should start from (optional)" } })
+        expect(summary.opg[1]).to include({ key: { text: "Enter a date this information should start from" } })
         expect(summary.opg[1]).to include({ value: { text: "2017-07-19" } })
-        expect(summary.opg[2]).to include({ key: { text: "Enter a date this information should go to (optional)" } })
+        expect(summary.opg[2]).to include({ key: { text: "Enter a date this information should go to" } })
         expect(summary.opg[2]).to include({ value: { text: "2019-03-02" } })
       end
     end
@@ -362,7 +362,7 @@ RSpec.describe InformationRequestSummary, type: :model do
       end
 
       it "returns dates information is required for" do
-        expect(summary.moj_other[2]).to include({ key: { text: "Enter a date this information should go to (optional)" } })
+        expect(summary.moj_other[2]).to include({ key: { text: "Enter a date this information should go to" } })
         expect(summary.moj_other[2]).to include({ value: { text: "1990-12-31" } })
       end
     end

--- a/spec/requests/prison_information_spec.rb
+++ b/spec/requests/prison_information_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Data required from prison service", type: :request do
 
         it "renders the expected page" do
           expect(response).to render_template(:edit)
-          expect(response.body).to include("What was your prison number (optional)?")
+          expect(response.body).to include("What was your prison number? (optional)")
         end
 
         it_behaves_like "question that accepts valid data", :prison_number


### PR DESCRIPTION
- Move question mark to before "(optional)" https://dsdmoj.atlassian.net/browse/CDPT-1783
- Remove "(optional)" on pages where the whole question is marked as optional on the page https://dsdmoj.atlassian.net/browse/CDPT-1784