### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -8,7 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
     external-dns.alpha.kubernetes.io/set-identifier: request-personal-information-ingress-staging-request-personal-information-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=request-personal-information-staging"
 spec:
+  ingressClassName: modsec
   ingressClassName: default
   tls:
   - hosts:


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.