### PR TITLE
CDPT-2010 Update personal information charter link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ node_modules
 /node_modules
 
 /coverage
+/.idea

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body">Use this service to request personal information for yourself or someone else who has given you permission to act on their behalf.</p>
     <p class="govuk-body">You have the right to access your personal information, known as a subject access request (SAR), under the Data Protection Act 2018.</p>
-    <p class="govuk-body">To understand more on the data we hold about you, your rights and how to contact us about it, please read through our <%= govuk_link_to "Personal Information charter", "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" %></p>
+    <p class="govuk-body">To understand more on the data we hold about you, your rights and how to contact us about it, please read through our <%= govuk_link_to "personal information charter", "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" %></p>
     <p class="govuk-body">This form allows you request information held by parts of the Ministry of Justice, including the:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>Prison Service - for security and NOMIS records about time spent in prison</li>


### PR DESCRIPTION
On the landing page the link for the personal information charter should be in sentence case.
Addition of .Rubymine .idea folder to gitignore list.

Jira ticket:
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?assignee=557058%3A2d2f4a33-f427-483f-9c36-338caee60eae&selectedIssue=CDPT-2010