### PR TITLE
Fix back button bug

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -31,6 +31,8 @@ class RequestsController < ApplicationController
     upcoming
   ].freeze
 
+  before_action :enable_back_button
+
   def new
     reset_session
     redirect_to "/#{STEPS.first}"
@@ -106,6 +108,10 @@ class RequestsController < ApplicationController
   def complete; end
 
 private
+
+  def enable_back_button
+    response.headers["Cache-Control"] = "no-store"
+  end
 
   def requested_step
     request.env["PATH_INFO"][1..]

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -110,7 +110,7 @@ class RequestsController < ApplicationController
 private
 
   def enable_back_button
-    response.headers["Cache-Control"] = "no-store"
+    response.headers["Cache-Control"] = "no-store, no-cache"
   end
 
   def requested_step


### PR DESCRIPTION
The form was breaking when using the back button and resubmitting a form. 
Disallowing caching makes it work. "no-store" is the required value, but "no-cache" is also required for older browsers (< IE10)