### PR TITLE
Add ruby as platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,6 +613,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  ruby
   x86_64-darwin-23
   x86_64-linux
 


### PR DESCRIPTION
Build fails without this.