### PR TITLE
CDPT-2291 Update list of mime types

### DIFF
--- a/app/validators/file_type_validator.rb
+++ b/app/validators/file_type_validator.rb
@@ -2,7 +2,15 @@ class FileTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless value
 
-    allowed_types = options[:allowed] || %w[image/jpg image/jpeg image/png application/pdf application/doc application/docx]
+    allowed_types = options[:allowed] || %w[
+      image/jpeg
+      image/gif
+      image/png
+      application/pdf
+      application/rtf
+      application/msword
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    ]
 
     unless allowed_types.include?(value.content_type)
       record.errors.add attribute, "The selected file must be a PDF, image (jpg, .jpeg, .png) or Microsoft Word document (.doc, .docx)"


### PR DESCRIPTION
Fixes issue with uploading word documents.

Removes invalid mime types:
  - image/jpg
  - application/doc
  - application/docx

Adds
  - application/rtf (.rtf)
  - application/msword (.doc)
  - application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx)