### PR TITLE
Use default allowed filetypes

### DIFF
--- a/app/models/request_form/subject_address.rb
+++ b/app/models/request_form/subject_address.rb
@@ -5,7 +5,7 @@ module RequestForm
     attr_accessor :default
 
     validates :subject_proof_of_address, presence: true, unless: -> { Attachment.exists?(subject_proof_of_address_id) }
-    validates :subject_proof_of_address, file_size: { max: 7.megabytes }, file_type: { allowed: %w[image/jpg image/jpeg image/png application/pdf application/doc application/docx] }
+    validates :subject_proof_of_address, file_size: { max: 7.megabytes }, file_type: true
     def required?
       !request.by_solicitor?
     end

--- a/app/models/request_form/subject_id.rb
+++ b/app/models/request_form/subject_id.rb
@@ -5,8 +5,7 @@ module RequestForm
     attr_accessor :default
 
     validates :subject_photo, presence: true, unless: -> { Attachment.exists?(subject_photo_id) }
-    validates :subject_photo, file_size: { max: 7.megabytes }
-    validates :subject_photo, file_type: { allowed: %w[image/jpg image/jpeg image/png application/pdf application/doc application/docx] }
+    validates :subject_photo, file_size: { max: 7.megabytes }, file_type: true
 
     def required?
       !request.by_solicitor?

--- a/app/validators/file_type_validator.rb
+++ b/app/validators/file_type_validator.rb
@@ -2,7 +2,15 @@ class FileTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless value
 
-    allowed_types = options[:allowed] || %w[image/jpg image/jpeg image/png application/pdf application/doc application/docx]
+    allowed_types = options[:allowed] || %w[
+      image/jpeg
+      image/gif
+      image/png
+      application/pdf
+      application/rtf
+      application/msword
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    ]
 
     unless allowed_types.include?(value.content_type)
       record.errors.add attribute, "The selected file must be a PDF, image (jpg, .jpeg, .png) or Microsoft Word document (.doc, .docx)"

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :attachment do
     key { "letter_of_consent" }
-    file { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
+    file { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
   end
 end

--- a/spec/factories/information_requests.rb
+++ b/spec/factories/information_requests.rb
@@ -26,20 +26,20 @@ FactoryBot.define do
     end
 
     trait :with_consent do
-      letter_of_consent { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
+      letter_of_consent { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
     end
 
     trait :with_requester_id do
-      requester_photo { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
-      requester_proof_of_address { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
+      requester_photo { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
+      requester_proof_of_address { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
     end
 
     trait :with_subject_id do
-      subject_photo { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
+      subject_photo { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
     end
 
     trait :with_subject_address do
-      subject_proof_of_address { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpg") }
+      subject_proof_of_address { Rack::Test::UploadedFile.new("spec/fixtures/files/file.jpg", "image/jpeg") }
     end
 
     trait :prison_service do

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe "Subject", type: :request do
     it_behaves_like "question that must be accessed in order"
 
     context "when session in progress" do
-      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpg") }
+      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpeg") }
       let(:invalid_data) { nil }
 
       before do
@@ -296,7 +296,7 @@ RSpec.describe "Subject", type: :request do
     it_behaves_like "question that must be accessed in order"
 
     context "when session in progress" do
-      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpg") }
+      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpeg") }
       let(:invalid_data) { nil }
 
       before do


### PR DESCRIPTION
Removes the custom filetypes defined in the models, and always uses the default.
Also sets the mimetype for the file used in tests to a valid one.