### PR TITLE
CDPT-2212 Add letter of consent to upload check page

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -8,8 +8,8 @@ class RequestsController < ApplicationController
     requester-details
     requester-id
     requester-address
-    requester-id-check
     letter-of-consent
+    requester-id-check
     letter-of-consent-check
     subject-id
     subject-address

--- a/app/models/request_form/letter_of_consent_check.rb
+++ b/app/models/request_form/letter_of_consent_check.rb
@@ -11,7 +11,7 @@ module RequestForm
     validate :check_value
 
     def required?
-      !request.for_self?
+      request.by_solicitor?
     end
 
   private

--- a/app/views/requests/_requester_id_check.html.erb
+++ b/app/views/requests/_requester_id_check.html.erb
@@ -7,11 +7,20 @@
         <%= govuk_link_to "Change", "/requester-id" %>
       <% end %>
     <% end %>
+
     <% body.with_row do |row| %>
       <% row.with_cell(header: true, text: 'Proof of address') %>
       <% row.with_cell(text: @information_request.requester_proof_of_address.to_s) %>
       <% row.with_cell do %>
         <%= govuk_link_to "Change", "/requester-address" %>
+      <% end %>
+    <% end %>
+
+    <% body.with_row do |row| %>
+      <% row.with_cell(header: true, text: 'Letter of consent') %>
+      <% row.with_cell(text: @information_request.letter_of_consent.to_s) %>
+      <% row.with_cell do %>
+        <%= govuk_link_to "Change", "/letter-of-consent" %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/factories/information_requests.rb
+++ b/spec/factories/information_requests.rb
@@ -95,7 +95,6 @@ FactoryBot.define do
     factory :information_request_for_other, traits: %i[for_other]
     factory :information_request_by_solicitor, traits: %i[for_other by_solicitor with_consent]
     factory :information_request_by_friend, traits: %i[for_other by_friend with_consent with_requester_id with_requester_address with_subject_id with_subject_address]
-    factory :information_request_with_consent, traits: %i[for_other with_consent]
     factory :information_request_with_requester_id, traits: %i[for_other with_requester_id with_requester_address]
     factory :information_request_with_subject_id, traits: %i[for_other with_subject_id with_subject_address]
     factory :information_request_for_prison_service, traits: %i[for_self prison_service]

--- a/spec/features/request_by_family_spec.rb
+++ b/spec/features/request_by_family_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Request by solicitor", type: :feature do
+RSpec.feature "Request by family", type: :feature do
   scenario "User makes end to end request" do
     visit "/"
 
@@ -37,16 +37,12 @@ RSpec.feature "Request by solicitor", type: :feature do
     attach_file("request-form-requester-proof-of-address-field", "spec/fixtures/files/file.jpg")
     click_button "Continue"
 
-    # Confirm upload
-    choose "Yes, add these uploads"
-    click_button "Continue"
-
     # Letter of Consent
     attach_file("request-form-letter-of-consent-field", "spec/fixtures/files/file.jpg")
     click_button "Continue"
 
     # Confirm upload
-    choose "Yes, add this upload"
+    choose "Yes, add these uploads"
     click_button "Continue"
 
     # Upload their photo ID

--- a/spec/models/request_form/letter_of_consent_check_spec.rb
+++ b/spec/models/request_form/letter_of_consent_check_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RequestForm::LetterOfConsentCheck, type: :model do
-  it_behaves_like "question when requester is not the subject"
+  it_behaves_like "question for solicitor"
   it_behaves_like "question with standard saveable attributes"
 
   describe "validation" do

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -86,119 +86,6 @@ RSpec.describe "Requester", type: :request do
     end
   end
 
-  describe "/letter-of-consent" do
-    let(:information_request) { build(:information_request_for_other) }
-    let(:current_step) { "letter-of-consent" }
-    let(:previous_step) { "requester-details" }
-    let(:next_step) { "/letter-of-consent-check" }
-
-    it_behaves_like "question that requires a session"
-    it_behaves_like "question that must be accessed in order"
-
-    context "when session in progress" do
-      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpeg") }
-      let(:invalid_data) { nil }
-
-      before do
-        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
-        get "/#{current_step}"
-      end
-
-      it "renders the expected page" do
-        expect(response).to render_template(:edit)
-        expect(response.body).to include("Upload a letter of consent")
-      end
-
-      context "when submitting form with invalid data" do
-        it "renders page with error message" do
-          patch "/request", params: { request_form: { letter_of_consent: invalid_data } }
-          expect(response).to render_template(:edit)
-          expect(response.body).to include("There is a problem")
-          expect(response.body).to include("Choose a file to upload")
-        end
-      end
-
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { letter_of_consent: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the associated ID to the session" do
-          patch "/request", params: { request_form: { letter_of_consent: valid_data } }
-          expect(request.session[:information_request][:letter_of_consent_id]).to be_an Integer
-        end
-      end
-
-      it_behaves_like "question with back link"
-    end
-
-    context "when returning to page" do
-      let(:letter_of_consent) { create(:attachment) }
-      let(:information_request) { build(:information_request_for_other, letter_of_consent_id: letter_of_consent.id) }
-
-      before do
-        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
-        get "/#{current_step}"
-      end
-
-      it "doesn't require repeat upload" do
-        patch "/request", params: { request_form: { letter_of_consent_id: letter_of_consent.id } }
-        expect(response).to redirect_to(next_step)
-      end
-    end
-  end
-
-  describe "/letter-of-consent-check" do
-    let(:information_request) { build(:information_request_with_consent) }
-    let(:current_step) { "letter-of-consent-check" }
-
-    it_behaves_like "question that requires a session"
-    it_behaves_like "question that must be accessed in order"
-
-    context "when session in progress" do
-      let(:previous_step) { "letter-of-consent" }
-      let(:next_step) { "/subject-id" }
-      let(:valid_data) { "yes" }
-      let(:invalid_data) { "" }
-
-      before do
-        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
-        get "/#{current_step}"
-      end
-
-      it "renders the expected page" do
-        expect(response).to render_template(:edit)
-        expect(response.body).to include("Check your upload")
-      end
-
-      context "when submitting form with invalid data" do
-        it "renders page with error message" do
-          patch "/request", params: { request_form: { letter_of_consent_check: invalid_data } }
-          expect(response).to render_template(:edit)
-          expect(response.body).to include("There is a problem")
-          expect(response.body).to include("Enter an answer for is this upload is correct")
-        end
-      end
-
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { letter_of_consent_check: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-      end
-
-      context "when the user wants to change the upload" do
-        it "goes to previous step" do
-          patch "/request", params: { request_form: { letter_of_consent_check: "no" } }
-          expect(response).to redirect_to("/#{previous_step}")
-        end
-      end
-
-      it_behaves_like "question with back link"
-    end
-  end
-
   describe "/requester-id" do
     let(:information_request) { build(:information_request_for_other) }
     let(:current_step) { "requester-id" }
@@ -266,7 +153,7 @@ RSpec.describe "Requester", type: :request do
     let(:information_request) { build(:information_request_for_other) }
     let(:current_step) { "requester-address" }
     let(:previous_step) { "requester-id" }
-    let(:next_step) { "/requester-id-check" }
+    let(:next_step) { "/letter-of-consent" }
 
     it_behaves_like "question that requires a session"
     it_behaves_like "question that must be accessed in order"
@@ -325,6 +212,69 @@ RSpec.describe "Requester", type: :request do
     end
   end
 
+  describe "/letter-of-consent" do
+    let(:information_request) { build(:information_request_for_other) }
+    let(:current_step) { "letter-of-consent" }
+    let(:previous_step) { "requester-address" }
+    let(:next_step) { "/requester-id-check" }
+
+    it_behaves_like "question that requires a session"
+    it_behaves_like "question that must be accessed in order"
+
+    context "when session in progress" do
+      let(:valid_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+      let(:invalid_data) { nil }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
+        get "/#{current_step}"
+      end
+
+      it "renders the expected page" do
+        expect(response).to render_template(:edit)
+        expect(response.body).to include("Upload a letter of consent")
+      end
+
+      context "when submitting form with invalid data" do
+        it "renders page with error message" do
+          patch "/request", params: { request_form: { letter_of_consent: invalid_data } }
+          expect(response).to render_template(:edit)
+          expect(response.body).to include("There is a problem")
+          expect(response.body).to include("Choose a file to upload")
+        end
+      end
+
+      context "when submitting form with valid data" do
+        it "goes to next step" do
+          patch "/request", params: { request_form: { letter_of_consent: valid_data } }
+          expect(response).to redirect_to(next_step)
+        end
+
+        it "saves the associated ID to the session" do
+          patch "/request", params: { request_form: { letter_of_consent: valid_data } }
+          expect(request.session[:information_request][:letter_of_consent_id]).to be_an Integer
+        end
+      end
+
+      it_behaves_like "question with back link"
+    end
+
+    context "when returning to page" do
+      let(:letter_of_consent) { create(:attachment) }
+      let(:information_request) { build(:information_request_for_other, letter_of_consent_id: letter_of_consent.id) }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
+        get "/#{current_step}"
+      end
+
+      it "doesn't require repeat upload" do
+        patch "/request", params: { request_form: { letter_of_consent_id: letter_of_consent.id } }
+        expect(response).to redirect_to(next_step)
+      end
+    end
+  end
+
   describe "/requester-id-check" do
     let(:information_request) { build(:information_request_with_requester_id) }
     let(:current_step) { "requester-id-check" }
@@ -334,7 +284,7 @@ RSpec.describe "Requester", type: :request do
 
     context "when session in progress" do
       let(:previous_step) { "requester-id" }
-      let(:next_step) { "/letter-of-consent" }
+      let(:next_step) { "/subject-id" }
       let(:valid_data) { "yes" }
       let(:invalid_data) { "" }
 
@@ -367,6 +317,56 @@ RSpec.describe "Requester", type: :request do
       context "when the user wants to change the upload" do
         it "goes to previous step" do
           patch "/request", params: { request_form: { requester_id_check: "no" } }
+          expect(response).to redirect_to("/#{previous_step}")
+        end
+      end
+
+      it_behaves_like "question with back link"
+    end
+  end
+
+  describe "/letter-of-consent-check" do
+    let(:information_request) { build(:information_request_by_solicitor) }
+    let(:current_step) { "letter-of-consent-check" }
+
+    it_behaves_like "question that requires a session"
+    it_behaves_like "question that must be accessed in order"
+
+    context "when session in progress" do
+      let(:previous_step) { "letter-of-consent" }
+      let(:next_step) { "/moj" }
+      let(:valid_data) { "yes" }
+      let(:invalid_data) { "" }
+
+      before do
+        set_session(information_request: information_request.to_hash, current_step: previous_step, history: [previous_step, current_step])
+        get "/#{current_step}"
+      end
+
+      it "renders the expected page" do
+        expect(response).to render_template(:edit)
+        expect(response.body).to include("Check your upload")
+      end
+
+      context "when submitting form with invalid data" do
+        it "renders page with error message" do
+          patch "/request", params: { request_form: { letter_of_consent_check: invalid_data } }
+          expect(response).to render_template(:edit)
+          expect(response.body).to include("There is a problem")
+          expect(response.body).to include("Enter an answer for is this upload is correct")
+        end
+      end
+
+      context "when submitting form with valid data" do
+        it "goes to next step" do
+          patch "/request", params: { request_form: { letter_of_consent_check: valid_data } }
+          expect(response).to redirect_to(next_step)
+        end
+      end
+
+      context "when the user wants to change the upload" do
+        it "goes to previous step" do
+          patch "/request", params: { request_form: { letter_of_consent_check: "no" } }
           expect(response).to redirect_to("/#{previous_step}")
         end
       end


### PR DESCRIPTION
When the user is not the subject and not a legal representative, the letter of consent check should be done at the same time as the requester ID check.