### PR TITLE
Allow straight return to check page

### DIFF
--- a/app/models/request_form/base.rb
+++ b/app/models/request_form/base.rb
@@ -4,7 +4,7 @@ module RequestForm
     include ActiveModel::Attributes
     include ActiveModel::Validations
 
-    attr_accessor :request, :back
+    attr_accessor :request, :return_to
 
     def initialize(**args)
       super

--- a/app/views/requests/_letter_of_consent_check.html.erb
+++ b/app/views/requests/_letter_of_consent_check.html.erb
@@ -4,7 +4,7 @@
       <% row.with_cell(header: true, text: 'Letter of consent') %>
       <% row.with_cell(text: @information_request.letter_of_consent.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/letter-of-consent" %>
+        <%= govuk_link_to "Change", "/letter-of-consent?return_to=letter-of-consent-check" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/requests/_requester_id_check.html.erb
+++ b/app/views/requests/_requester_id_check.html.erb
@@ -4,7 +4,7 @@
       <% row.with_cell(header: true, text: 'Photo ID') %>
       <% row.with_cell(text: @information_request.requester_photo.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/requester-id" %>
+        <%= govuk_link_to "Change", "/requester-id?return_to=requester-id-check" %>
       <% end %>
     <% end %>
 
@@ -12,7 +12,7 @@
       <% row.with_cell(header: true, text: 'Proof of address') %>
       <% row.with_cell(text: @information_request.requester_proof_of_address.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/requester-address" %>
+        <%= govuk_link_to "Change", "/requester-address?return_to=requester-id-check" %>
       <% end %>
     <% end %>
 
@@ -20,7 +20,7 @@
       <% row.with_cell(header: true, text: 'Letter of consent') %>
       <% row.with_cell(text: @information_request.letter_of_consent.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/letter-of-consent" %>
+        <%= govuk_link_to "Change", "/letter-of-consent?return_to=requester-id-check" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/requests/_subject_id_check.html.erb
+++ b/app/views/requests/_subject_id_check.html.erb
@@ -4,7 +4,7 @@
       <% row.with_cell(header: true, text: 'Photo ID') %>
       <% row.with_cell(text: @information_request.subject_photo.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/subject-id" %>
+        <%= govuk_link_to "Change", "/subject-id?return_to=subject-id-check" %>
       <% end %>
     <% end %>
 
@@ -12,7 +12,7 @@
       <% row.with_cell(header: true, text: 'Proof of address') %>
       <% row.with_cell(text: @information_request.subject_proof_of_address.to_s) %>
       <% row.with_cell do %>
-        <%= govuk_link_to "Change", "/subject-address" %>
+        <%= govuk_link_to "Change", "/subject-address?return_to=subject-id-check" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/requests/edit.html.erb
+++ b/app/views/requests/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link(href: back_request_path) %>
+    <%= govuk_back_link(href: back_request_path(return_to: params[:return_to])) %>
     <%= form_with model: @form, scope: :request_form, url: request_path, method: :patch do |f| %>
       <% content_for(:form_content) { render partial: @form.name, locals: { f: } } %>
       <%= f.govuk_error_summary %>
@@ -9,6 +9,7 @@
         <%= content_for?(:title) ? yield(:title) : t("request_form.#{@form.name}") %>
       </h1>
       <%= yield :form_content %>
+      <%= f.hidden_field :return_to, value: @form.return_to %>
       <%= f.govuk_submit %>
       <% if t("request_form.#{@form.name}.#{@information_request.subject}_title", default: '').present? %>
         <%= govuk_details(summary_text: t("request_form.#{@form.name}.#{@information_request.subject}_title"), text: t("request_form.#{@form.name}.#{@information_request.subject}_details")) %>

--- a/spec/features/request_for_self_spec.rb
+++ b/spec/features/request_for_self_spec.rb
@@ -68,4 +68,43 @@ RSpec.feature "Request for self", type: :feature do
     # Form sent
     expect(page).to have_text("Request sent")
   end
+
+  scenario "User changes upload" do
+    visit "/"
+
+    # Start page
+    click_link "Start now"
+
+    # Subject
+    choose "My own"
+    click_button "Continue"
+
+    # Your details
+    fill_in("Full name", with: "John")
+    click_button "Continue"
+
+    # Date of birth
+    fill_in("Day", with: "1")
+    fill_in("Month", with: "1")
+    fill_in("Year", with: "2000")
+    click_button "Continue"
+
+    # Upload ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Upload address
+    attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Change upload
+    first("tr").click_link "Change"
+
+    # Upload new ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Back to check page
+    expect(page).to have_text("Check your uploads")
+  end
 end

--- a/spec/support/shared_session_examples.rb
+++ b/spec/support/shared_session_examples.rb
@@ -38,4 +38,14 @@ RSpec.shared_examples("question with back link") do
       expect(response).to redirect_to("/#{previous_step}")
     end
   end
+
+  context "when return path is specified" do
+    it "goes to specified step" do
+      history = session[:history] << "subject"
+      set_session(history:)
+
+      get("/request/back?return_to=subject")
+      expect(response).to redirect_to("/subject")
+    end
+  end
 end


### PR DESCRIPTION
When a user wants to change an upload, once they have finished on that page the next step will take them back to the check page.

A `return_to` param has been added that will cause the submission of the form and the back link to use the value in the return_to param.