### PR TITLE
Move size warning to separate line

### DIFF
--- a/app/views/requests/_requester_address.html.erb
+++ b/app/views/requests/_requester_address.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_file_field :requester_proof_of_address, label:nil, hint: { text: t("helpers.hint.request_form.requester_proof_of_address") } %>
+<%= f.govuk_file_field :requester_proof_of_address, label: nil %>
 
 <%= f.hidden_field :requester_proof_of_address_id %>
 <%= f.hidden_field :default %>

--- a/app/views/requests/_requester_id.html.erb
+++ b/app/views/requests/_requester_id.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_file_field :requester_photo, label:nil, hint: { text: t("helpers.hint.request_form.requester_photo") } %>
+<%= f.govuk_file_field :requester_photo, label: nil %>
 
 <%= f.hidden_field :requester_photo_id %>
 <%= f.hidden_field :default %>

--- a/app/views/requests/_subject_address.html.erb
+++ b/app/views/requests/_subject_address.html.erb
@@ -2,7 +2,7 @@
   <%= t("request_form.#{@form.name}.#{@information_request.subject}") %>
 <% end %>
 
-<%= f.govuk_file_field :subject_proof_of_address, label:nil, hint: { text: t("helpers.hint.request_form.subject_proof_of_address.#{@information_request.subject}") } %>
+<%= f.govuk_file_field :subject_proof_of_address, label:nil, hint: { text: t("helpers.hint.request_form.subject_proof_of_address.#{@information_request.subject}_html") } %>
 
 <%= f.hidden_field :subject_proof_of_address_id %>
 <%= f.hidden_field :default %>

--- a/app/views/requests/_subject_id.html.erb
+++ b/app/views/requests/_subject_id.html.erb
@@ -2,7 +2,7 @@
   <%= t("request_form.#{@form.name}.#{@information_request.subject}") %>
 <% end %>
 
-<%= f.govuk_file_field :subject_photo, label:nil, hint: { text: t("helpers.hint.request_form.subject_photo.#{@information_request.subject}") } %>
+<%= f.govuk_file_field :subject_photo, label:nil, hint: { text: t("helpers.hint.request_form.subject_photo.#{@information_request.subject}_html") } %>
 
 <%= f.hidden_field :subject_photo_id %>
 <%= f.hidden_field :default %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,10 +172,10 @@ en:
         form_moj_other_date_from: For example, 3 11 2000
         form_moj_other_date_to: For example, 12 5 2014
         letter_of_consent: |
-          You must provide a letter of consent from the subject of this request which: 
-            • states that they consent to their information being released to you 
-            • is signed by them 
-            • is dated within the last 6 months 
+          You must provide a letter of consent from the subject of this request which:
+            • states that they consent to their information being released to you
+            • is signed by them
+            • is dated within the last 6 months
           There is no official template
         letter_of_consent_file_size: "Maximum size: 7 MB"
         form_opg_date_from: For example, 3 11 2000
@@ -192,18 +192,18 @@ en:
         probation_office: Enter the town, city or area. For example, Macclesfield.
         form_probation_date_from: For example, 3 11 2000
         form_probation_date_to: For example, 12 5 2014
-        requester_photo: "For example, a copy of your driving licence or passport. This can be a photograph, scan or photocopy of the original document. Maximum size: 7 MB."
+        requester_photo_html: "For example, a copy of your driving licence or passport. This can be a photograph, scan or photocopy of the original document.<br>Maximum size: 7 MB."
         requester_proof_of_address: "For example an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document. Maximum size: 7 MB."
         subject_photo:
-          other: "For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document. Maximum size: 7 MB."
+          other_html: "For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document.<br>Maximum size: 7 MB."
           other_title: If they don’t have photo ID
           other_details: "If they are on probation and do not have photo ID, we will accept a letter signed by a probation officer on probation service headed paper. Upload this file here."
-          self: "For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document. Maximum size: 7 MB."
+          self_html: "For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document.<br>Maximum size: 7 MB."
         subject_proof_of_address:
-          other: "For example, an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document. Maximum size: 7 MB."
+          other_html: "For example, an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document.<br>Maximum size: 7 MB."
           other_title: If they don’t have proof of address
           other_details: "If they are on probation and do not have proof of address, we will accept a letter signed by a probation officer on probation service headed paper. Upload this file here."
-          self: "For example, an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document. Maximum size: 7 MB."
+          self_html: "For example, an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document.<br>Maximum size: 7 MB."
         upcoming_court_case_text: For example, when the trial or hearing is happening.
 
   request_form:

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe "Subject", type: :request do
         it "renders the expected page" do
           expect(response).to render_template(:edit)
           expect(response.body).to include("Upload your photo ID")
-          expect(response.body).to include("For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document. Maximum size: 7 MB.")
+          expect(response.body).to include("For example, a driving licence or passport. This can be a photograph, scan or photocopy of the original document.<br>Maximum size: 7 MB.")
         end
       end
 


### PR DESCRIPTION
Avoids awkward wrapping of text

Before:
<img width="658" alt="Screenshot 2024-11-28 at 15 57 16" src="https://github.com/user-attachments/assets/ddb93084-98d8-45d7-b4b1-71ebee33ad6e">

After:
<img width="641" alt="Screenshot 2024-11-28 at 15 56 48" src="https://github.com/user-attachments/assets/fb9d12c9-a671-4408-ab45-5fb94fdb61d0">
