### PR TITLE
CDPT-2250 Return to Check Answers page

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -34,6 +34,8 @@ class RequestsController < ApplicationController
     upcoming
   ].freeze
 
+  CHECK_ANSWERS_STEP = "check-answers".freeze
+
   before_action :enable_back_button
 
   def new
@@ -206,7 +208,7 @@ private
       index = current_index + 1
 
       if index >= STEPS.size
-        step = "check-answers"
+        step = CHECK_ANSWERS_STEP
         session[:history] << step unless session[:history].include?(step)
         redirect = "/#{step}"
       else
@@ -254,9 +256,13 @@ private
   def return_path
     return if return_to.blank?
 
-    if STEPS.include?(return_to.to_sym) && session[:history].include?(return_to)
+    if valid_return? && session[:history].include?(return_to)
       "/#{return_to}"
     end
+  end
+
+  def valid_return?
+    return_to == CHECK_ANSWERS_STEP || STEPS.include?(return_to.to_sym)
   end
 
   def return_to

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -262,7 +262,7 @@ private
   end
 
   def valid_return?
-    return_to == CHECK_ANSWERS_STEP || STEPS.include?(return_to.to_sym)
+    (return_to == CHECK_ANSWERS_STEP && @information_request.valid?) || STEPS.include?(return_to.to_sym)
   end
 
   def return_to

--- a/app/models/information_request_summary.rb
+++ b/app/models/information_request_summary.rb
@@ -10,17 +10,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.full_name") },
         value: { text: @information_request.full_name },
-        actions: { text: "Change", href: "/subject-name", visually_hidden_text: I18n.t("helpers.label.request_form.full_name") },
+        actions: { text: "Change", href: "/subject-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.full_name") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
         value: { text: @information_request.other_names },
-        actions: { text: "Change", href: "/subject-name", visually_hidden_text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
+        actions: { text: "Change", href: "/subject-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.subject_date_of_birth.#{@information_request.subject}") },
         value: { text: format_date(@information_request.date_of_birth) },
-        actions: { text: "Change", href: "/subject-date-of-birth", visually_hidden_text: I18n.t("helpers.label.request_form.date_of_birth") },
+        actions: { text: "Change", href: "/subject-date-of-birth#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.date_of_birth") },
       },
     ]
 
@@ -45,12 +45,12 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.organisation_name") },
           value: { text: @information_request.organisation_name },
-          actions: { text: "Change", href: "/solicitor-details", visually_hidden_text: I18n.t("helpers.label.request_form.organisation_name") },
+          actions: { text: "Change", href: "/solicitor-details#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.organisation_name") },
         },
         {
           key: { text: I18n.t("helpers.label.request_form.requester_name") },
           value: { text: @information_request.requester_name },
-          actions: { text: "Change", href: "/requester-name", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
+          actions: { text: "Change", href: "/requester-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
         },
       ]
     else
@@ -58,7 +58,7 @@ class InformationRequestSummary
         {
           key: { text: "Your full name" },
           value: { text: @information_request.requester_name },
-          actions: { text: "Change", href: "/requester-name", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
+          actions: { text: "Change", href: "/requester-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
         },
       ]
     end
@@ -74,12 +74,12 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.requester_photo") },
           value: { text: @information_request.requester_photo.to_s },
-          actions: { text: "Change", href: "/requester-id", visually_hidden_text: I18n.t("helpers.label.request_form.requester_photo") },
+          actions: { text: "Change", href: "/requester-id#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_photo") },
         },
         {
           key: { text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
           value: { text: @information_request.requester_proof_of_address.to_s },
-          actions: { text: "Change", href: "/requester-id", visually_hidden_text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
+          actions: { text: "Change", href: "/requester-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
         },
       )
     end
@@ -88,7 +88,7 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.letter_of_consent") },
         value: { text: @information_request.letter_of_consent.to_s },
-        actions: { text: "Change", href: "/letter-of-consent", visually_hidden_text: I18n.t("request_form.letter_of_consent") },
+        actions: { text: "Change", href: "/letter-of-consent#{return_query_string}", visually_hidden_text: I18n.t("request_form.letter_of_consent") },
       },
     )
 
@@ -102,12 +102,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.subject_photo") },
         value: { text: @information_request.subject_photo.to_s },
-        actions: { text: "Change", href: "/subject-id", visually_hidden_text: I18n.t("helpers.label.request_form.subject_photo") },
+        actions: { text: "Change", href: "/subject-id#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.subject_photo") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
         value: { text: @information_request.subject_proof_of_address.to_s },
-        actions: { text: "Change", href: "/subject-id", visually_hidden_text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
+        actions: { text: "Change", href: "/subject-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
       },
     ]
   end
@@ -130,7 +130,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
           value: { text: @information_request.recent_prison_name },
-          actions: { text: "Change", href: "/prison-location", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
+          actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
         },
       )
     end
@@ -140,7 +140,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
           value: { text: @information_request.currently_in_prison.capitalize },
-          actions: { text: "Change", href: "/prison-location", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
+          actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
         },
       )
 
@@ -149,7 +149,7 @@ class InformationRequestSummary
           {
             key: { text: I18n.t("helpers.label.request_form.current_prison_name") },
             value: { text: @information_request.current_prison_name },
-            actions: { text: "Change", href: "/prison-location", visually_hidden_text: I18n.t("helpers.label.request_form.current_prison_name") },
+            actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.current_prison_name") },
           },
         )
       else
@@ -157,7 +157,7 @@ class InformationRequestSummary
           {
             key: { text: I18n.t("helpers.label.request_form.recent_prison_name") },
             value: { text: @information_request.recent_prison_name },
-            actions: { text: "Change", href: "/prison-location", visually_hidden_text: I18n.t("helpers.label.request_form.recent_prison_name") },
+            actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.recent_prison_name") },
           },
         )
       end
@@ -167,12 +167,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
         value: { text: @information_request.prison_number },
-        actions: { text: "Change", href: "/prison-number", visually_hidden_text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
+        actions: { text: "Change", href: "/prison-number#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.prison_information") },
         value: { text: format_list(@information_request.prison_information) },
-        actions: { text: "Change", href: "/prison-information", visually_hidden_text: I18n.t("request_form.prison_information") },
+        actions: { text: "Change", href: "/prison-information#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_information") },
       },
     )
 
@@ -181,7 +181,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.prison_other_data_text") },
           value: { text: @information_request.prison_other_data_text },
-          actions: { text: "Change", href: "/prison-information", visually_hidden_text: I18n.t("helpers.label.request_form.prison_other_data_text") },
+          actions: { text: "Change", href: "/prison-information#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.prison_other_data_text") },
         },
       )
     end
@@ -190,12 +190,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
         value: { text: format_date(@information_request.prison_date_from) },
-        actions: { text: "Change", href: "/prison-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
+        actions: { text: "Change", href: "/prison-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
         value: { text: format_date(@information_request.prison_date_to) },
-        actions: { text: "Change", href: "/prison-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
+        actions: { text: "Change", href: "/prison-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
       },
     )
 
@@ -209,12 +209,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
         value: { text: @information_request.probation_office },
-        actions: { text: "Change", href: "/probation-location", visually_hidden_text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
+        actions: { text: "Change", href: "/probation-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.probation_information") },
         value: { text: format_list(@information_request.probation_information) },
-        actions: { text: "Change", href: "/probation-information", visually_hidden_text: I18n.t("request_form.probation_information") },
+        actions: { text: "Change", href: "/probation-information#{return_query_string}", visually_hidden_text: I18n.t("request_form.probation_information") },
       },
     ]
 
@@ -223,7 +223,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.probation_other_data_text") },
           value: { text: @information_request.probation_other_data_text },
-          actions: { text: "Change", href: "/probation-information", visually_hidden_text: I18n.t("helpers.label.request_form.probation_other_data_text") },
+          actions: { text: "Change", href: "/probation-information#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.probation_other_data_text") },
         },
       )
     end
@@ -232,12 +232,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
         value: { text: format_date(@information_request.probation_date_from) },
-        actions: { text: "Change", href: "/probation-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
+        actions: { text: "Change", href: "/probation-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
         value: { text: format_date(@information_request.probation_date_to) },
-        actions: { text: "Change", href: "/probation-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
+        actions: { text: "Change", href: "/probation-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
       },
     )
 
@@ -251,17 +251,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.laa") },
         value: { text: @information_request.laa_text },
-        actions: { text: "Change", href: "/laa", visually_hidden_text: I18n.t("request_form.laa") },
+        actions: { text: "Change", href: "/laa#{return_query_string}", visually_hidden_text: I18n.t("request_form.laa") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
         value: { text: format_date(@information_request.laa_date_from) },
-        actions: { text: "Change", href: "/laa-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
+        actions: { text: "Change", href: "/laa-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
         value: { text: format_date(@information_request.laa_date_to) },
-        actions: { text: "Change", href: "/laa-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
+        actions: { text: "Change", href: "/laa-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
       },
     ]
   end
@@ -273,17 +273,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.opg") },
         value: { text: @information_request.opg_text },
-        actions: { text: "Change", href: "/opg", visually_hidden_text: I18n.t("request_form.opg") },
+        actions: { text: "Change", href: "/opg#{return_query_string}", visually_hidden_text: I18n.t("request_form.opg") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
         value: { text: format_date(@information_request.opg_date_from) },
-        actions: { text: "Change", href: "/opg-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
+        actions: { text: "Change", href: "/opg-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
         value: { text: format_date(@information_request.opg_date_to) },
-        actions: { text: "Change", href: "/opg-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
+        actions: { text: "Change", href: "/opg-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
       },
     ]
   end
@@ -296,22 +296,22 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.other_where") },
         value: { text: @information_request.moj_other_where },
-        actions: { text: "Change", href: "/other-where", visually_hidden_text: I18n.t("request_form.other_where") },
+        actions: { text: "Change", href: "/other-where#{return_query_string}", visually_hidden_text: I18n.t("request_form.other_where") },
       },
       {
         key: { text: I18n.t("request_form.other") },
         value: { text: @information_request.moj_other_text },
-        actions: { text: "Change", href: "/other", visually_hidden_text: I18n.t("request_form.other") },
+        actions: { text: "Change", href: "/other#{return_query_string}", visually_hidden_text: I18n.t("request_form.other") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
         value: { text: format_date(@information_request.moj_other_date_from) },
-        actions: { text: "Change", href: "/other-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
+        actions: { text: "Change", href: "/other-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
         value: { text: format_date(@information_request.moj_other_date_to) },
-        actions: { text: "Change", href: "/other-dates", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
+        actions: { text: "Change", href: "/other-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
       },
     ]
   end
@@ -321,17 +321,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.contact_address") },
         value: { text: @information_request.contact_address },
-        actions: { text: "Change", href: "/contact-address", visually_hidden_text: I18n.t("helpers.label.request_form.contact_address") },
+        actions: { text: "Change", href: "/contact-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.contact_address") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.contact_email") },
         value: { text: @information_request.contact_email },
-        actions: { text: "Change", href: "/contact-email", visually_hidden_text: I18n.t("helpers.label.request_form.contact_email") },
+        actions: { text: "Change", href: "/contact-email#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.contact_email") },
       },
       {
         key: { text: I18n.t("request_form.upcoming") },
         value: { text: @information_request.upcoming_court_case.capitalize },
-        actions: { text: "Change", href: "/upcoming", visually_hidden_text: I18n.t("request_form.upcoming") },
+        actions: { text: "Change", href: "/upcoming#{return_query_string}", visually_hidden_text: I18n.t("request_form.upcoming") },
       },
     ]
 
@@ -340,7 +340,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
           value: { text: @information_request.upcoming_court_case_text },
-          actions: { text: "Change", href: "/upcoming", visually_hidden_text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
+          actions: { text: "Change", href: "/upcoming#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
         },
       )
     end
@@ -356,5 +356,9 @@ private
 
   def format_date(date)
     date&.to_fs(:day_month_and_year)
+  end
+
+  def return_query_string
+    "?return_to=check-answers"
   end
 end

--- a/app/models/information_request_summary.rb
+++ b/app/models/information_request_summary.rb
@@ -10,17 +10,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.full_name") },
         value: { text: @information_request.full_name },
-        actions: { text: "Change", href: "/subject-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.full_name") },
+        actions: { text: "Change", href: with_query_string("/subject-name"), visually_hidden_text: I18n.t("helpers.label.request_form.full_name") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
         value: { text: @information_request.other_names },
-        actions: { text: "Change", href: "/subject-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
+        actions: { text: "Change", href: with_query_string("/subject-name"), visually_hidden_text: I18n.t("helpers.label.request_form.other_names.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.subject_date_of_birth.#{@information_request.subject}") },
         value: { text: format_date(@information_request.date_of_birth) },
-        actions: { text: "Change", href: "/subject-date-of-birth#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.date_of_birth") },
+        actions: { text: "Change", href: with_query_string("/subject-date-of-birth"), visually_hidden_text: I18n.t("helpers.label.request_form.date_of_birth") },
       },
     ]
 
@@ -29,7 +29,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("request_form.subject_relationship") },
           value: { text: RequestForm::SubjectRelationship::OPTIONS[@information_request.relationship.to_sym] },
-          actions: { text: "Change", href: "/subject-relationship", visually_hidden_text: I18n.t("request_form.subject_relationship") },
+          actions: { text: "Change", href: with_query_string("/subject-relationship"), visually_hidden_text: I18n.t("request_form.subject_relationship") },
         },
       )
     end
@@ -45,12 +45,12 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.organisation_name") },
           value: { text: @information_request.organisation_name },
-          actions: { text: "Change", href: "/solicitor-details#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.organisation_name") },
+          actions: { text: "Change", href: with_query_string("/solicitor-details#"), visually_hidden_text: I18n.t("helpers.label.request_form.organisation_name") },
         },
         {
           key: { text: I18n.t("helpers.label.request_form.requester_name") },
           value: { text: @information_request.requester_name },
-          actions: { text: "Change", href: "/requester-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
+          actions: { text: "Change", href: with_query_string("/requester-name"), visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
         },
       ]
     else
@@ -58,7 +58,7 @@ class InformationRequestSummary
         {
           key: { text: "Your full name" },
           value: { text: @information_request.requester_name },
-          actions: { text: "Change", href: "/requester-name#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
+          actions: { text: "Change", href: with_query_string("/requester-name"), visually_hidden_text: I18n.t("helpers.label.request_form.requester_name") },
         },
       ]
     end
@@ -74,12 +74,12 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.requester_photo") },
           value: { text: @information_request.requester_photo.to_s },
-          actions: { text: "Change", href: "/requester-id#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_photo") },
+          actions: { text: "Change", href: with_query_string("/requester-id"), visually_hidden_text: I18n.t("helpers.label.request_form.requester_photo") },
         },
         {
           key: { text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
           value: { text: @information_request.requester_proof_of_address.to_s },
-          actions: { text: "Change", href: "/requester-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
+          actions: { text: "Change", href: with_query_string("/requester-address"), visually_hidden_text: I18n.t("helpers.label.request_form.requester_proof_of_address") },
         },
       )
     end
@@ -88,7 +88,7 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.letter_of_consent") },
         value: { text: @information_request.letter_of_consent.to_s },
-        actions: { text: "Change", href: "/letter-of-consent#{return_query_string}", visually_hidden_text: I18n.t("request_form.letter_of_consent") },
+        actions: { text: "Change", href: with_query_string("/letter-of-consent"), visually_hidden_text: I18n.t("request_form.letter_of_consent") },
       },
     )
 
@@ -102,12 +102,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.subject_photo") },
         value: { text: @information_request.subject_photo.to_s },
-        actions: { text: "Change", href: "/subject-id#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.subject_photo") },
+        actions: { text: "Change", href: with_query_string("/subject-id"), visually_hidden_text: I18n.t("helpers.label.request_form.subject_photo") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
         value: { text: @information_request.subject_proof_of_address.to_s },
-        actions: { text: "Change", href: "/subject-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
+        actions: { text: "Change", href: with_query_string("/subject-address"), visually_hidden_text: I18n.t("helpers.label.request_form.subject_proof_of_address") },
       },
     ]
   end
@@ -116,7 +116,7 @@ class InformationRequestSummary
     [{
       key: { text: I18n.t("helpers.hint.request_form.moj") },
       value: { text: format_list(@information_request.information_required) },
-      actions: { text: "Change", href: "/moj", visually_hidden_text: I18n.t("helpers.hint.request_form.moj") },
+      actions: { text: "Change", href: with_query_string("/moj"), visually_hidden_text: I18n.t("helpers.hint.request_form.moj") },
     }]
   end
 
@@ -130,7 +130,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
           value: { text: @information_request.recent_prison_name },
-          actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
+          actions: { text: "Change", href: with_query_string("/prison-location"), visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
         },
       )
     end
@@ -140,7 +140,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
           value: { text: @information_request.currently_in_prison.capitalize },
-          actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
+          actions: { text: "Change", href: with_query_string("/prison-location"), visually_hidden_text: I18n.t("request_form.prison_location.#{@information_request.subject}") },
         },
       )
 
@@ -149,7 +149,7 @@ class InformationRequestSummary
           {
             key: { text: I18n.t("helpers.label.request_form.current_prison_name") },
             value: { text: @information_request.current_prison_name },
-            actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.current_prison_name") },
+            actions: { text: "Change", href: with_query_string("/prison-location"), visually_hidden_text: I18n.t("helpers.label.request_form.current_prison_name") },
           },
         )
       else
@@ -157,7 +157,7 @@ class InformationRequestSummary
           {
             key: { text: I18n.t("helpers.label.request_form.recent_prison_name") },
             value: { text: @information_request.recent_prison_name },
-            actions: { text: "Change", href: "/prison-location#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.recent_prison_name") },
+            actions: { text: "Change", href: with_query_string("/prison-location"), visually_hidden_text: I18n.t("helpers.label.request_form.recent_prison_name") },
           },
         )
       end
@@ -167,12 +167,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
         value: { text: @information_request.prison_number },
-        actions: { text: "Change", href: "/prison-number#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
+        actions: { text: "Change", href: with_query_string("/prison-number"), visually_hidden_text: I18n.t("request_form.prison_number.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.prison_information") },
         value: { text: format_list(@information_request.prison_information) },
-        actions: { text: "Change", href: "/prison-information#{return_query_string}", visually_hidden_text: I18n.t("request_form.prison_information") },
+        actions: { text: "Change", href: with_query_string("/prison-information"), visually_hidden_text: I18n.t("request_form.prison_information") },
       },
     )
 
@@ -181,7 +181,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.prison_other_data_text") },
           value: { text: @information_request.prison_other_data_text },
-          actions: { text: "Change", href: "/prison-information#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.prison_other_data_text") },
+          actions: { text: "Change", href: with_query_string("/prison-information"), visually_hidden_text: I18n.t("helpers.label.request_form.prison_other_data_text") },
         },
       )
     end
@@ -190,12 +190,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
         value: { text: format_date(@information_request.prison_date_from) },
-        actions: { text: "Change", href: "/prison-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
+        actions: { text: "Change", href: with_query_string("/prison-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
         value: { text: format_date(@information_request.prison_date_to) },
-        actions: { text: "Change", href: "/prison-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
+        actions: { text: "Change", href: with_query_string("/prison-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_prison_date_to") },
       },
     )
 
@@ -209,12 +209,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
         value: { text: @information_request.probation_office },
-        actions: { text: "Change", href: "/probation-location#{return_query_string}", visually_hidden_text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
+        actions: { text: "Change", href: with_query_string("/probation-location"), visually_hidden_text: I18n.t("request_form.probation_location.#{@information_request.subject}") },
       },
       {
         key: { text: I18n.t("request_form.probation_information") },
         value: { text: format_list(@information_request.probation_information) },
-        actions: { text: "Change", href: "/probation-information#{return_query_string}", visually_hidden_text: I18n.t("request_form.probation_information") },
+        actions: { text: "Change", href: with_query_string("/probation-information"), visually_hidden_text: I18n.t("request_form.probation_information") },
       },
     ]
 
@@ -223,7 +223,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.probation_other_data_text") },
           value: { text: @information_request.probation_other_data_text },
-          actions: { text: "Change", href: "/probation-information#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.probation_other_data_text") },
+          actions: { text: "Change", href: with_query_string("/probation-information"), visually_hidden_text: I18n.t("helpers.label.request_form.probation_other_data_text") },
         },
       )
     end
@@ -232,12 +232,12 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
         value: { text: format_date(@information_request.probation_date_from) },
-        actions: { text: "Change", href: "/probation-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
+        actions: { text: "Change", href: with_query_string("/probation-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
         value: { text: format_date(@information_request.probation_date_to) },
-        actions: { text: "Change", href: "/probation-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
+        actions: { text: "Change", href: with_query_string("/probation-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_probation_date_to") },
       },
     )
 
@@ -251,17 +251,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.laa") },
         value: { text: @information_request.laa_text },
-        actions: { text: "Change", href: "/laa#{return_query_string}", visually_hidden_text: I18n.t("request_form.laa") },
+        actions: { text: "Change", href: with_query_string("/laa"), visually_hidden_text: I18n.t("request_form.laa") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
         value: { text: format_date(@information_request.laa_date_from) },
-        actions: { text: "Change", href: "/laa-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
+        actions: { text: "Change", href: with_query_string("/laa-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
         value: { text: format_date(@information_request.laa_date_to) },
-        actions: { text: "Change", href: "/laa-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
+        actions: { text: "Change", href: with_query_string("/laa-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_laa_date_to") },
       },
     ]
   end
@@ -273,17 +273,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.opg") },
         value: { text: @information_request.opg_text },
-        actions: { text: "Change", href: "/opg#{return_query_string}", visually_hidden_text: I18n.t("request_form.opg") },
+        actions: { text: "Change", href: with_query_string("/opg"), visually_hidden_text: I18n.t("request_form.opg") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
         value: { text: format_date(@information_request.opg_date_from) },
-        actions: { text: "Change", href: "/opg-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
+        actions: { text: "Change", href: with_query_string("/opg-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
         value: { text: format_date(@information_request.opg_date_to) },
-        actions: { text: "Change", href: "/opg-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
+        actions: { text: "Change", href: with_query_string("/opg-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_opg_date_to") },
       },
     ]
   end
@@ -296,22 +296,22 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("request_form.other_where") },
         value: { text: @information_request.moj_other_where },
-        actions: { text: "Change", href: "/other-where#{return_query_string}", visually_hidden_text: I18n.t("request_form.other_where") },
+        actions: { text: "Change", href: with_query_string("/other-where"), visually_hidden_text: I18n.t("request_form.other_where") },
       },
       {
         key: { text: I18n.t("request_form.other") },
         value: { text: @information_request.moj_other_text },
-        actions: { text: "Change", href: "/other#{return_query_string}", visually_hidden_text: I18n.t("request_form.other") },
+        actions: { text: "Change", href: with_query_string("/other"), visually_hidden_text: I18n.t("request_form.other") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
         value: { text: format_date(@information_request.moj_other_date_from) },
-        actions: { text: "Change", href: "/other-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
+        actions: { text: "Change", href: with_query_string("/other-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_from") },
       },
       {
         key: { text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
         value: { text: format_date(@information_request.moj_other_date_to) },
-        actions: { text: "Change", href: "/other-dates#{return_query_string}", visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
+        actions: { text: "Change", href: with_query_string("/other-dates"), visually_hidden_text: I18n.t("helpers.legend.request_form.form_moj_other_date_to") },
       },
     ]
   end
@@ -321,17 +321,17 @@ class InformationRequestSummary
       {
         key: { text: I18n.t("helpers.label.request_form.contact_address") },
         value: { text: @information_request.contact_address },
-        actions: { text: "Change", href: "/contact-address#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.contact_address") },
+        actions: { text: "Change", href: with_query_string("/contact-address"), visually_hidden_text: I18n.t("helpers.label.request_form.contact_address") },
       },
       {
         key: { text: I18n.t("helpers.label.request_form.contact_email") },
         value: { text: @information_request.contact_email },
-        actions: { text: "Change", href: "/contact-email#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.contact_email") },
+        actions: { text: "Change", href: with_query_string("/contact-email"), visually_hidden_text: I18n.t("helpers.label.request_form.contact_email") },
       },
       {
         key: { text: I18n.t("request_form.upcoming") },
         value: { text: @information_request.upcoming_court_case.capitalize },
-        actions: { text: "Change", href: "/upcoming#{return_query_string}", visually_hidden_text: I18n.t("request_form.upcoming") },
+        actions: { text: "Change", href: with_query_string("/upcoming"), visually_hidden_text: I18n.t("request_form.upcoming") },
       },
     ]
 
@@ -340,7 +340,7 @@ class InformationRequestSummary
         {
           key: { text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
           value: { text: @information_request.upcoming_court_case_text },
-          actions: { text: "Change", href: "/upcoming#{return_query_string}", visually_hidden_text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
+          actions: { text: "Change", href: with_query_string("/upcoming"), visually_hidden_text: I18n.t("helpers.label.request_form.upcoming_court_case_text") },
         },
       )
     end
@@ -358,7 +358,7 @@ private
     date&.to_fs(:day_month_and_year)
   end
 
-  def return_query_string
-    "?return_to=check-answers"
+  def with_query_string(path)
+    "#{path}?return_to=check-answers"
   end
 end

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -8,7 +8,7 @@
       summary_list.with_row do |row|
         row.with_key { t("request_form.subject") }
         row.with_value { RequestForm::Subject::OPTIONS[@information_request.subject.to_sym] }
-        row.with_action(text: "Change", href: "/subject", visually_hidden_text: t("request_form.subject"))
+        row.with_action(text: "Change", href: "/subject?return_to=check-answers", visually_hidden_text: t("request_form.subject"))
       end;
     end %>
 

--- a/spec/features/check_answers_spec.rb
+++ b/spec/features/check_answers_spec.rb
@@ -1,0 +1,193 @@
+require "rails_helper"
+
+RSpec.feature "Edit answers", type: :feature do
+  scenario "User changes upload" do
+    visit "/"
+
+    # Start page
+    click_link "Start now"
+
+    # Subject
+    choose "My own"
+    click_button "Continue"
+
+    # Your details
+    fill_in("Full name", with: "John")
+    click_button "Continue"
+
+    # Date of birth
+    fill_in("Day", with: "1")
+    fill_in("Month", with: "1")
+    fill_in("Year", with: "2000")
+    click_button "Continue"
+
+    # Upload ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Upload address
+    attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Change upload
+    first("tr").click_link "Change"
+
+    # Upload new ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Back to check page
+    expect(page).to have_text("Check your uploads")
+  end
+
+  scenario "User adds all data and then edits answers" do
+    visit "/"
+
+    # Start page
+    click_link "Start now"
+
+    # Subject
+    choose "My own"
+    click_button "Continue"
+
+    # Your details
+    fill_in("Full name", with: "John")
+    click_button "Continue"
+
+    # Date of birth
+    fill_in("Day", with: "1")
+    fill_in("Month", with: "1")
+    fill_in("Year", with: "2000")
+    click_button "Continue"
+
+    # Upload ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Upload address
+    attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Contine
+    click_button "Continue"
+
+    # Information from where
+    check "Prison service"
+    click_button "Continue"
+
+    # Prison name
+    fill_in("request-form-recent-prison-name-field", with: "HMP Brixton")
+    click_button "Continue"
+
+    # Prison number
+    click_button "Continue"
+
+    # Types of information
+    check "NOMIS Records"
+    click_button "Continue"
+
+    # Date range
+    click_button "Continue"
+
+    # Requester address
+    fill_in("Your address", with: "1 High Street")
+    click_button "Continue"
+
+    # Your email
+    click_button "Continue"
+
+    # Upcoming case?
+    choose "No"
+    click_button "Continue"
+
+    # Check answers
+    expect(page).to have_text("Check your answers")
+
+    # Change name
+    within all(".govuk-summary-list__row")[1] do
+      click_link "Change"
+    end
+    expect(page).to have_text("What is your name?")
+    fill_in("Full name", with: "Michael")
+    click_button "Continue"
+
+    # See changed name
+    expect(page).to have_text("Check your answers")
+    expect(page).to have_text("Michael")
+  end
+
+  scenario "User adds all data and then edits answers that requires additional information" do
+    visit "/"
+
+    # Start page
+    click_link "Start now"
+
+    # Subject
+    choose "My own"
+    click_button "Continue"
+
+    # Your details
+    fill_in("Full name", with: "John")
+    click_button "Continue"
+
+    # Date of birth
+    fill_in("Day", with: "1")
+    fill_in("Month", with: "1")
+    fill_in("Year", with: "2000")
+    click_button "Continue"
+
+    # Upload ID
+    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Upload address
+    attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/file.jpg")
+    click_button "Continue"
+
+    # Contine
+    click_button "Continue"
+
+    # Information from where
+    check "Prison service"
+    click_button "Continue"
+
+    # Prison name
+    fill_in("request-form-recent-prison-name-field", with: "HMP Brixton")
+    click_button "Continue"
+
+    # Prison number
+    click_button "Continue"
+
+    # Types of information
+    check "NOMIS Records"
+    click_button "Continue"
+
+    # Date range
+    click_button "Continue"
+
+    # Requester address
+    fill_in("Your address", with: "1 High Street")
+    click_button "Continue"
+
+    # Your email
+    click_button "Continue"
+
+    # Upcoming case?
+    choose "No"
+    click_button "Continue"
+
+    # Check answers
+    expect(page).to have_text("Check your answers")
+
+    # Change who is requesting
+    within all(".govuk-summary-list__row")[0] do
+      click_link "Change"
+    end
+    expect(page).to have_text("Are you requesting your own information or someone else's?")
+    choose "Someone else's"
+    click_button "Continue"
+
+    # Goes to next form, not check answers
+    expect(page).to have_text("What is their name?")
+  end
+end

--- a/spec/features/request_for_self_spec.rb
+++ b/spec/features/request_for_self_spec.rb
@@ -68,43 +68,4 @@ RSpec.feature "Request for self", type: :feature do
     # Form sent
     expect(page).to have_text("Request sent")
   end
-
-  scenario "User changes upload" do
-    visit "/"
-
-    # Start page
-    click_link "Start now"
-
-    # Subject
-    choose "My own"
-    click_button "Continue"
-
-    # Your details
-    fill_in("Full name", with: "John")
-    click_button "Continue"
-
-    # Date of birth
-    fill_in("Day", with: "1")
-    fill_in("Month", with: "1")
-    fill_in("Year", with: "2000")
-    click_button "Continue"
-
-    # Upload ID
-    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
-    click_button "Continue"
-
-    # Upload address
-    attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/file.jpg")
-    click_button "Continue"
-
-    # Change upload
-    first("tr").click_link "Change"
-
-    # Upload new ID
-    attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
-    click_button "Continue"
-
-    # Back to check page
-    expect(page).to have_text("Check your uploads")
-  end
 end

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -33,18 +33,7 @@ RSpec.describe "contact information", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { contact_address: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { contact_address: valid_data } }
-          expect(request.session[:information_request][:contact_address]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :contact_address
       it_behaves_like "question with back link"
     end
   end
@@ -81,18 +70,7 @@ RSpec.describe "contact information", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { contact_email: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { contact_email: valid_data } }
-          expect(request.session[:information_request][:contact_email]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :contact_email
       it_behaves_like "question with back link"
     end
   end
@@ -129,18 +107,7 @@ RSpec.describe "contact information", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { upcoming_court_case: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { upcoming_court_case: valid_data } }
-          expect(request.session[:information_request][:upcoming_court_case]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :upcoming_court_case
       it_behaves_like "question with back link"
 
       context "when user has upcoming court case" do

--- a/spec/requests/other_information_spec.rb
+++ b/spec/requests/other_information_spec.rb
@@ -81,18 +81,7 @@ RSpec.describe "Which data is required", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { laa_text: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { laa_text: valid_data } }
-          expect(request.session[:information_request][:laa_text]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :laa_text
       it_behaves_like "question with back link"
     end
   end
@@ -175,18 +164,7 @@ RSpec.describe "Which data is required", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { opg_text: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { opg_text: valid_data } }
-          expect(request.session[:information_request][:opg_text]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :opg_text
       it_behaves_like "question with back link"
     end
   end
@@ -269,18 +247,7 @@ RSpec.describe "Which data is required", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { moj_other_where: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { moj_other_where: valid_data } }
-          expect(request.session[:information_request][:moj_other_where]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :moj_other_where
       it_behaves_like "question with back link"
     end
   end
@@ -317,18 +284,7 @@ RSpec.describe "Which data is required", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { moj_other_text: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { moj_other_text: valid_data } }
-          expect(request.session[:information_request][:moj_other_text]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :moj_other_text
       it_behaves_like "question with back link"
     end
   end

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -70,18 +70,7 @@ RSpec.describe "Requester", type: :request do
         end
       end
 
-      context "when submitting form with valid data" do
-        it "goes to next step" do
-          patch "/request", params: { request_form: { requester_name: valid_data } }
-          expect(response).to redirect_to(next_step)
-        end
-
-        it "saves the value to the session" do
-          patch "/request", params: { request_form: { requester_name: valid_data } }
-          expect(request.session[:information_request][:requester_name]).to eq valid_data
-        end
-      end
-
+      it_behaves_like "question that accepts valid data", :requester_name
       it_behaves_like "question with back link"
     end
   end


### PR DESCRIPTION
When the user makes a change from the "change-answers" page, after submitting they should be taken back to "check-answers" instead of having to go through all steps.

This does not apply to pages that can lead to additional information being required. e.g. if they change who is requesting the information, or what type of information is required.