### PR TITLE
Enable build and deploy from PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,10 +116,11 @@ jobs:
   notify-staging:
     needs: [build, deploy-staging]
     uses: ./.github/workflows/notification.yml
+    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: secrets.SLACK_WEBHOOK_URL
+      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -180,15 +181,17 @@ jobs:
   notify-production:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
+    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: secrets.SLACK_WEBHOOK_URL
+      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   notify-production-2:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
+    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: secrets.PROD_SLACK_WEBHOOK_URL
+      webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     environment: build
 
+    steps:
+      run: echo "Build approval"
+
   build:
     runs-on: ubuntu-latest
     needs: build-approval

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,8 @@ jobs:
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      prod_slack_webhook_url: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ steps.vars.outputs.SLACK_WEBHOOK_URL }}
+      prod_slack_webhook_url: ${{ steps.vars.outputs.PROD_SLACK_WEBHOOK_URL }}
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -41,13 +41,15 @@ jobs:
       - name: Store current date
         run: echo "BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_ENV
 
-      - name: Store build tag
+      - name: Store build tag and webhooks
         id: vars
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           short_sha=$(git rev-parse --short $SHA)
           build_tag=$PREFIX-$branch-$short_sha
           echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
+          echo "slack_webhook_url=$SLACK_WEBHOOK_URL" >> $GITHUB_OUTPUT
+          echo "prod_slack_webhook_url=$PROD_SLACK_WEBHOOK_URL" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+      webhook: secrets.SLACK_WEBHOOK_URL
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -191,4 +191,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+      webhook: secrets.PROD_SLACK_WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
 env:
   PREFIX: "rpi"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+  KUBE_CERT: ${{ secrets.KUBE_CERT }}
+  KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -67,12 +71,6 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
 
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,12 +129,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     environment: build
 
     steps:
-      run: echo "Build approval"
+      - run: echo "Build approval"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: ${{ $SLACK_WEBHOOK_URL }}
+      webhook: ${{ env.SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ $SLACK_WEBHOOK_URL }}
+      webhook: ${{ env.SLACK_WEBHOOK_URL }}
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -193,4 +193,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ $PROD_SLACK_WEBHOOK_URL }}
+      webhook: ${{ env.PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-approval:
     if: ${{ github.ref != 'refs/heads/main' }}
+    runs-on: ubuntu-latest
     environment: build
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,12 @@ jobs:
     environment: build
 
     steps:
-      - run: echo "Build approval"
+      - run: echo "Build approved"
 
   build:
     runs-on: ubuntu-latest
     needs: build-approval
+    if: ${{ always() }}
 
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-approval:
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/build-pr' }}
     runs-on: ubuntu-latest
     environment: build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,11 +117,13 @@ jobs:
 
   notify-staging:
     needs: [build, deploy-staging]
-    uses: ./.github/workflows/notification.yml
-    with:
-      build_tag: ${{ needs.build.outputs.build_tag }}
-      environment: Staging
-      webhook: ${{ env.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Slack notification
+        uses: ./.github/workflows/notification.yml
+        with:
+          build_tag: ${{ needs.build.outputs.build_tag }}
+          environment: Staging
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ concurrency:
 
 jobs:
   build-approval:
-    if: ${{ github.ref == 'refs/heads/main' }}
-
-  build-approval:
     if: ${{ github.ref != 'refs/heads/main' }}
     environment: build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-approval:
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+  build-approval:
+    if: ${{ github.ref != 'refs/heads/main' }}
+    environment: build
+
   build:
     runs-on: ubuntu-latest
+    needs: build-approval
 
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,10 +116,10 @@ jobs:
   notify-staging:
     needs: [build, deploy-staging]
     uses: ./.github/workflows/notification.yml
-      with:
-        build_tag: ${{ needs.build.outputs.build_tag }}
-        environment: Staging
-        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Staging
+      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -180,15 +180,15 @@ jobs:
   notify-production:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
-      with:
-        build_tag: ${{ needs.build.outputs.build_tag }}
-        environment: Productio
-        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production
+      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   notify-production-2:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
-      with:
-        build_tag: ${{ needs.build.outputs.build_tag }}
-        environment: Productio
-        webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production
+      webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}
+      slack_webhook_url: $SLACK_WEBHOOK_URL
+      prod_slack_webhook_url: $PROD_SLACK_WEBHOOK_URL
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -116,15 +118,12 @@ jobs:
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
   notify-staging:
-    runs-on: ubuntu-latest
     needs: [build, deploy-staging]
-    steps:
-      - name: Slack notification
-        uses: ./.github/workflows/notification.yml
-        with:
-          build_tag: ${{ needs.build.outputs.build_tag }}
-          environment: Staging
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: ./.github/workflows/notification.yml
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Staging
+      webhook: ${{ needs.build.outputs.slack_webhook_url }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -188,7 +187,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: $SLACK_WEBHOOK_URL
+      webhook: ${{ needs.build.outputs.slack_webhook_url }}
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -196,4 +195,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: $PROD_SLACK_WEBHOOK_URL
+      webhook: ${{ needs.build.outputs.prod_slack_webhook_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 env:
   PREFIX: "rpi"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  PROD_SLACK_WEBHOOK_URL: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -116,11 +118,10 @@ jobs:
   notify-staging:
     needs: [build, deploy-staging]
     uses: ./.github/workflows/notification.yml
-    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+      webhook: ${{ SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -181,17 +182,15 @@ jobs:
   notify-production:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
-    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+      webhook: ${{ SLACK_WEBHOOK_URL }}
 
   notify-production-2:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
-    secrets: inherit
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+      webhook: ${{ PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,7 +188,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ env.SLACK_WEBHOOK_URL }}
+      webhook: $SLACK_WEBHOOK_URL
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -196,4 +196,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ env.PROD_SLACK_WEBHOOK_URL }}
+      webhook: $PROD_SLACK_WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-approval:
-    # if: ${{ github.ref != 'refs/heads/main' }}
-    if: false
-    runs-on: ubuntu-latest
-    environment: build
-
-    steps:
-      - run: echo "Build approved"
-
   build:
     runs-on: ubuntu-latest
-    needs: build-approval
-    if: ${{ always() }}
 
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,8 @@ jobs:
           short_sha=$(git rev-parse --short $SHA)
           build_tag=$PREFIX-$branch-$short_sha
           echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
-          echo "slack_webhook_url=$SLACK_WEBHOOK_URL" >> $GITHUB_OUTPUT
-          echo "prod_slack_webhook_url=$PROD_SLACK_WEBHOOK_URL" >> $GITHUB_OUTPUT
+          echo "slack_webhook_url=${{ secrets.SLACK_WEBHOOK_URL }}" >> $GITHUB_OUTPUT
+          echo "prod_slack_webhook_url=${{ secrets.PROD_SLACK_WEBHOOK_URL }}" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: $SLACK_WEBHOOK_URL
+      webhook: ${{ $SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: $SLACK_WEBHOOK_URL
+      webhook: ${{ $SLACK_WEBHOOK_URL }}
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -193,4 +193,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: $PROD_SLACK_WEBHOOK_URL
+      webhook: ${{ $PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}
-      slack_webhook_url: ${{ steps.vars.outputs.slack_webhook_url }}
-      prod_slack_webhook_url: ${{ steps.vars.outputs.prod_slack_webhook_url }}
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -41,15 +39,13 @@ jobs:
       - name: Store current date
         run: echo "BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_ENV
 
-      - name: Store build tag and webhooks
+      - name: Store build tag
         id: vars
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           short_sha=$(git rev-parse --short $SHA)
           build_tag=$PREFIX-$branch-$short_sha
           echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
-          echo "slack_webhook_url=${{ secrets.SLACK_WEBHOOK_URL }}" >> $GITHUB_OUTPUT
-          echo "prod_slack_webhook_url=${{ secrets.PROD_SLACK_WEBHOOK_URL }}" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |
@@ -120,10 +116,11 @@ jobs:
   notify-staging:
     needs: [build, deploy-staging]
     uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: ${{ needs.build.outputs.slack_webhook_url }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -184,15 +181,17 @@ jobs:
   notify-production:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ needs.build.outputs.slack_webhook_url }}
 
   notify-production-2:
     needs: [build, deploy-production]
     uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ needs.build.outputs.prod_slack_webhook_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,33 +119,11 @@ jobs:
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
       - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: ./.github/workflows/notification.yml
         with:
+          build_tag: ${{ steps.vars.outputs.build_tag }}
+          environment: Staging
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Staging*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Request for Personal Information",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -212,59 +190,15 @@ jobs:
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
       - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: ./.github/workflows/notification.yml
         with:
+          build_tag: ${{ steps.vars.outputs.build_tag }}
+          environment: Production
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Request for Personal Information",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
 
       - name: Send deploy notification to production deploys Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: ./.github/workflows/notification.yml
         with:
+          build_tag: ${{ steps.vars.outputs.build_tag }}
+          environment: Production
           webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Request for Personal Information",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,8 @@ jobs:
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}
-      slack_webhook_url: ${{ steps.vars.outputs.SLACK_WEBHOOK_URL }}
-      prod_slack_webhook_url: ${{ steps.vars.outputs.PROD_SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ steps.vars.outputs.slack_webhook_url }}
+      prod_slack_webhook_url: ${{ steps.vars.outputs.prod_slack_webhook_url }}
 
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,6 @@ on:
 env:
   PREFIX: "rpi"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  PROD_SLACK_WEBHOOK_URL: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -19,8 +17,8 @@ jobs:
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}
-      slack_webhook_url: $SLACK_WEBHOOK_URL
-      prod_slack_webhook_url: $PROD_SLACK_WEBHOOK_URL
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      prod_slack_webhook_url: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
 
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    outputs:
+      build_tag: ${{ steps.vars.outputs.build_tag }}
+
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
@@ -84,14 +87,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
 
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
-
       - name: Tag build and push to ECR
         run: |
           docker pull ${{ vars.ECR_URL }}:$SHA
@@ -118,12 +113,13 @@ jobs:
           jobs="${{ vars.ECR_URL }}:$SHA" \
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
-      - name: Send deploy notification to product Slack channel
-        uses: ./.github/workflows/notification.yml
-        with:
-          build_tag: ${{ steps.vars.outputs.build_tag }}
-          environment: Staging
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+  notify-staging:
+    needs: [build, deploy-staging]
+    uses: ./.github/workflows/notification.yml
+      with:
+        build_tag: ${{ needs.build.outputs.build_tag }}
+        environment: Staging
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -155,14 +151,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
 
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
-
       - name: Tag build and push to ECR
         run: |
           docker pull ${{ vars.ECR_URL }}:$SHA
@@ -189,16 +177,18 @@ jobs:
           jobs="${{ vars.ECR_URL }}:$SHA" \
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
-      - name: Send deploy notification to product Slack channel
-        uses: ./.github/workflows/notification.yml
-        with:
-          build_tag: ${{ steps.vars.outputs.build_tag }}
-          environment: Production
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+  notify-production:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+      with:
+        build_tag: ${{ needs.build.outputs.build_tag }}
+        environment: Productio
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Send deploy notification to production deploys Slack channel
-        uses: ./.github/workflows/notification.yml
-        with:
-          build_tag: ${{ steps.vars.outputs.build_tag }}
-          environment: Production
-          webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+  notify-production-2:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+      with:
+        build_tag: ${{ needs.build.outputs.build_tag }}
+        environment: Productio
+        webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,7 @@ jobs:
           webapp="${{ vars.ECR_URL }}:$SHA" --local --output yaml | kubectl apply -n $KUBE_NAMESPACE -f -
 
   notify-staging:
+    runs-on: ubuntu-latest
     needs: [build, deploy-staging]
     steps:
       - name: Slack notification

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+      webhook: secrets.SLACK_WEBHOOK_URL
 
   deploy-production:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   build-approval:
-    if: ${{ github.ref != 'refs/heads/build-pr' }}
+    # if: ${{ github.ref != 'refs/heads/main' }}
+    if: false
     runs-on: ubuntu-latest
     environment: build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy Workflow
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Staging
-      webhook: ${{ SLACK_WEBHOOK_URL }}
+      webhook: $SLACK_WEBHOOK_URL
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ SLACK_WEBHOOK_URL }}
+      webhook: $SLACK_WEBHOOK_URL
 
   notify-production-2:
     needs: [build, deploy-production]
@@ -193,4 +193,4 @@ jobs:
     with:
       build_tag: ${{ needs.build.outputs.build_tag }}
       environment: Production
-      webhook: ${{ PROD_SLACK_WEBHOOK_URL }}
+      webhook: $PROD_SLACK_WEBHOOK_URL

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -16,7 +16,11 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,0 +1,47 @@
+name: Notification Workflow
+
+on:
+  workflow_call:
+    inputs:
+      build_tag:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      webhook:
+        required: true
+        type: string
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ inputs.webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#1d990c",
+                  "text": "${{ github.actor }} deployed *${{ inputs.build_tag }}* to *${{ inputs.environment }}*",
+                  "fields": [
+                    {
+                      "title": "Project",
+                      "value": "Request for Personal Information",
+                      "short": true
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "text": "Visit Job",
+                      "type": "button",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -2,14 +2,14 @@ name: Notification Workflow
 
 on:
   workflow_call:
+    secrets:
+      webhook_url:
+        required: true
     inputs:
       build_tag:
         required: true
         type: string
       environment:
-        required: true
-        type: string
-      webhook:
         required: true
         type: string
 
@@ -21,7 +21,7 @@ jobs:
       - name: Slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ inputs.webhook }}
+          webhook: ${{ secrets.webhook_url }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -35,13 +35,7 @@ jobs:
                       "short": true
                     }
                   ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
+                  "footer": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                 }
               ]
             }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,9 +66,9 @@ jobs:
   build-and-deploy:
     if: ${{ github.ref != 'refs/heads/main' }}
     needs: test
-    environment: build
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
+    environment: build
 
   build-and-deploy-main:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,13 @@ jobs:
           minimum_file_coverage: 100
 
   build-and-deploy:
+    if: ${{ github.ref != 'refs/heads/main' }}
+    needs: test
+    environment: build
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit
+
+  build-and-deploy-main:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,8 @@ jobs:
           minimum_suite_coverage: 100
           minimum_file_coverage: 100
 
-  build-and-deploy:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    needs: test
-    uses: ./.github/workflows/deploy.yml
-    secrets: inherit
-    environment: build
-
   build-and-deploy-main:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     uses: ./.github/workflows/deploy.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           minimum_suite_coverage: 100
           minimum_file_coverage: 100
 
-  build-and-deploy-main:
+  build-and-deploy:
     needs: test
     uses: ./.github/workflows/deploy.yml
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
           minimum_file_coverage: 100
 
   build-and-deploy-main:
-    # if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     uses: ./.github/workflows/deploy.yml
     secrets: inherit


### PR DESCRIPTION
Every commit to a PR will now build the app ready to deploy. This means that a deploy can be made from the PR checks.

Also removes duplicated code to create build tag and send slack notifications.