### PR TITLE
CDPT-2431 RPI: Remove help link from footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
     </div>
 
     <%= govuk_footer(meta_items_title: "Support links", meta_items: {
-      t("footer.help") => "https://www.gov.uk/help", t("footer.cookie") => "https://www.gov.uk/help/cookies" }) %>
+      t("footer.cookie") => "https://www.gov.uk/help/cookies" }) %>
 
     <%= render "shared/debug" if Rails.env.development? %>
   </body>


### PR DESCRIPTION
Remove help link ( which takes the user to the gov.uk page ) from footer.