### PR TITLE
CDPT-2433 RPI: Amend the gov.uk link on page to navigate to Welcome GOV.UK

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(homepage_url: "/", service_name: t("service.name")) %>
+    <%= govuk_header(homepage_url: "https://www.gov.uk/", service_name: t("service.name")) %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is a new service – your feedback will help us to improve it. ") %>


### PR DESCRIPTION
Amend the GOV.UK logo link to the https://www.gov.uk/