### PR TITLE
CDPT-2465: Create accessibility statement

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
   def homepage; end
+
+  def accessibility; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,8 @@
     </div>
 
     <%= govuk_footer(meta_items_title: "Support links", meta_items: {
-      t("footer.cookie") => "https://www.gov.uk/help/cookies" }) %>
+      t("layouts.application.footer.cookie") => "https://www.gov.uk/help/cookies",
+      t("layouts.application.footer.accessibility") => accessibility_path }) %>
 
     <%= render "shared/debug" if Rails.env.development? %>
   </body>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,0 +1,44 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility statement</h1>
+
+    <p class="govuk-body">This accessibility statement applies to the Request personal information form at: <%= govuk_link_to "https://request-personal-info.form.service.justice.gov.uk" %>.</p>
+    <p class="govuk-body">This form was built by the Ministry of Justice. Justice Digital is responsible for the content of this form.</p>
+    <h2 class="govuk-heading-m">Using this form</h2>
+    <p class="govuk-body">We want as many people as possible to be able to use this form. For example, that means you should be able to:</p>
+    <%= govuk_list ["change colours, contrast levels and fonts",
+                    "zoom in up to 300% without the text spilling off the screen",
+                    "navigate the form using just a keyboard",
+                    "navigate the form using speech recognition software",
+                    "listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)"], type: :bullet %>
+
+    <p class="govuk-body">We have also made the text as simple as possible to understand.</p>
+    <p class="govuk-body"><%= govuk_link_to "AbilityNet", "https://mcmw.abilitynet.org.uk/" %> has advice on making your device easier to use if you have a disability.</p>
+
+    <h2 class="govuk-heading-m">How accessible this form is</h2>
+    <p class="govuk-body">We have performed a basic accessibility check of this form and believe it meets the <%= govuk_link_to "Web Content Accessibility Guidelines version 2.2 AA standard", "https://www.w3.org/TR/WCAG22/" %>.</p>
+
+    <h2 class="govuk-heading-m">Feedback and contact information</h2>
+    <p class="govuk-body">If you require an alternative method of making a subject access request to this online form, you can also make a request by email or letter. Follow the guidance set out in the  <%= govuk_link_to "Personal information charter", "https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter" %>.</p>
+    <p class="govuk-body">If you have problems using this form or need additional support, email <%= t("pages.accessibility.sar_research_email_html")%>.</p>
+
+    <h2 class="govuk-heading-m">Reporting accessibility problems with this form</h2>
+    <p class="govuk-body">We're always looking to improve the accessibility of this form. If you find any problems or think we're not meeting accessibility requirements, email: <%= t("pages.accessibility.sar_research_email_html")%>.</p>
+
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
+    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, contact the <%= govuk_link_to "Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com/" %>.</p>
+ 
+    <h2 class="govuk-heading-m">Technical information about this form's accessibility</h2>
+    <p class="govuk-body">We are committed to making this form accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+
+    <h3 class="govuk-heading-s">Compliance status</h3>
+    <p class="govuk-body">This form is fully compliant with the <%= govuk_link_to "Web Content Accessibility Guidelines version 2.2 AA standard", "https://www.w3.org/TR/WCAG22/" %>.</p>
+
+    <h2 class="govuk-heading-m">What we're doing to improve accessibility</h2>
+    <p class="govuk-body">We review the content and performance of this site on an ongoing basis and fix any accessibility issues identified or reported to us.</p>
+
+    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
+    <p class="govuk-body">This statement was prepared on 30 January 2025.</p>
+    <p class="govuk-body">The tests on the website were carried out by the Ministry of Justice. We completed accessibility checks on a representative sample of pages using keyboard testing and the WAVE automated testing tool.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,7 +200,14 @@ en:
           other_details: "If they are on probation and do not have proof of address, we will accept a letter signed by a probation officer on probation service headed paper. Upload this file here."
           self_html: "For example, an electricity or council tax bill. It must be dated within the last 6 months. This can be a photograph, scan or copy of the original document.<br>Maximum size: 7 MB."
         upcoming_court_case_text: For example, when the trial or hearing is happening.
-
+  layouts:
+    application:
+      footer:
+        cookie: Cookies
+        accessibility: Accessibility
+  pages:
+    accessibility:
+      sar_research_email_html: "<a href='mailto:sar.research@digital.justice.gov.uk'>sar.research@digital.justice.gov.uk</a>"
   request_form:
     contact_address: Where we'll send the information
     contact_email: Your email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     get "/back", to: "requests#back"
   end
 
+  get "accessibility" => "pages#accessibility", as: "accessibility"
+
   get "subject" => "requests#edit"
   get "subject-name" => "requests#edit"
   get "subject-date-of-birth" => "requests#edit"

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe "Pages", type: :request do
       expect(response.body).to include("Request personal information from the Ministry of Justice")
     end
   end
+
+  describe "#accessibility" do
+    it "shows the accessibility page" do
+      get "/accessibility"
+      expect(response).to be_successful
+      expect(response.body).to include("Accessibility statement")
+    end
+  end
 end


### PR DESCRIPTION
Add the accessibility statement.

We discussed adding a back link or opening in a new tab, but have decided for now to do nothing. This is because we don't believe there is a standard practice and the back link required more work due to edge case bugs.