### PR TITLE
Fix favicon and how assets are made available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ COPY . .
 RUN RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 \
     bundle exec rails assets:precompile
 
+# Copy govuk assets
+RUN cp -r node_modules/govuk-frontend/dist/govuk/assets/. public/assets/
+
 # Cleanup to save space in the production image
 RUN rm -rf node_modules log/* tmp/* /tmp && \
     rm -rf /usr/local/bundle/cache

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
 //= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds
 //= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets/images

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,1 @@
-$govuk-new-typography-scale: true;
-$govuk-assets-path: "govuk/assets/";
-
-@import "govuk/all";
+@use "govuk-frontend/dist/govuk/index";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,10 +8,10 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_path('/govuk/assets/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag asset_path('/govuk/assets/images/favicon.ico'), sizes: '48x48' %>
-    <%= favicon_link_tag asset_path('/govuk/assets/images/favicon.svg'), type: 'image/svg+xml', sizes: 'any' %>
-    <%= favicon_link_tag asset_path('/govuk/assets/images/govuk-icon-mask.svg'), rel: 'mask-icon', color: '#0b0c0c' %>
-    <%= favicon_link_tag asset_path('/govuk/assets/images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_path('images/favicon.ico'), sizes: '48x48' %>
+    <%= favicon_link_tag asset_path('images/favicon.svg'), type: 'image/svg+xml', sizes: 'any' %>
+    <%= favicon_link_tag asset_path('images/govuk-icon-mask.svg'), rel: 'mask-icon', color: '#0b0c0c' %>
+    <%= favicon_link_tag asset_path('images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
     <%= javascript_include_tag "application", defer: true %>
     <%= stylesheet_link_tag "application" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,8 @@
 Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
-Rails.application.config.assets.paths << "node_modules/govuk-frontend/dist"
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets")
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
Refactors how assets are made available from govuk-frontend. 
Adds `node_modules` to assets path to load the CSS, and adds the specific path to the assets folder for images and fonts.

Also copies assets to the public folder so they will be compiled for production use.