### PR TITLE
CDPT-2571: Fix invalid file saving

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -36,6 +36,14 @@ class RequestsController < ApplicationController
 
   CHECK_ANSWERS_STEP = "check-answers".freeze
 
+  ATTACHMENT_MAPPINGS = {
+    "requester-id" => "requester_photo_id",
+    "subject-id" => "subject_photo_id",
+    "letter-of-consent" => "letter_of_consent_id",
+    "subject-address" => "subject_proof_of_address_id",
+    "requester-address" => "requester_proof_of_address_id",
+  }.freeze
+
   before_action :enable_back_button
 
   def new
@@ -86,6 +94,10 @@ class RequestsController < ApplicationController
       session[:information_request] = @information_request.to_hash
       next_step
     else
+      attribute = @form.attributes[ATTACHMENT_MAPPINGS[session[:current_step]]]
+      if attachment_step? && Attachment.exists?(attribute)
+        Attachment.find(attribute).destroy!
+      end
       render :edit
     end
   end
@@ -267,5 +279,9 @@ private
 
   def return_to
     params[:return_to] || (params[:request_form].present? && request_params[:return_to])
+  end
+
+  def attachment_step?
+    session[:current_step].in?(%w[requester-id subject-id letter-of-consent subject-address requester-address])
   end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -36,7 +36,7 @@ class RequestsController < ApplicationController
 
   CHECK_ANSWERS_STEP = "check-answers".freeze
 
-  ATTACHMENT_MAPPINGS = {
+  ATTACHMENT_ID_MAPPINGS = {
     "requester-id" => "requester_photo_id",
     "subject-id" => "subject_photo_id",
     "letter-of-consent" => "letter_of_consent_id",
@@ -94,9 +94,9 @@ class RequestsController < ApplicationController
       session[:information_request] = @information_request.to_hash
       next_step
     else
-      attribute = @form.attributes[ATTACHMENT_MAPPINGS[session[:current_step]]]
-      if attachment_step? && Attachment.exists?(attribute)
-        Attachment.find(attribute).destroy!
+      attachment_id = @form.attributes[ATTACHMENT_ID_MAPPINGS[session[:current_step]]]
+      if Attachment.exists?(attachment_id)
+        Attachment.find(attachment_id).destroy!
       end
       render :edit
     end
@@ -279,9 +279,5 @@ private
 
   def return_to
     params[:return_to] || (params[:request_form].present? && request_params[:return_to])
-  end
-
-  def attachment_step?
-    session[:current_step].in?(%w[requester-id subject-id letter-of-consent subject-address requester-address])
   end
 end

--- a/spec/features/request_by_family_spec.rb
+++ b/spec/features/request_by_family_spec.rb
@@ -103,6 +103,7 @@ RSpec.feature "Request by family", type: :feature do
       expect(page).to have_text("Upload your photo ID")
       click_button "Continue"
       expect(page).not_to have_text("Upload your proof of address")
+      expect(page).to have_text("There is a problem")
       expect(page).to have_text("Upload your photo ID")
     end
 
@@ -113,6 +114,9 @@ RSpec.feature "Request by family", type: :feature do
       expect(page).to have_text("Upload your proof of address")
       # Upload address
       attach_file("request-form-requester-proof-of-address-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your proof of address")
       click_button "Continue"
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Upload your proof of address")
@@ -129,6 +133,9 @@ RSpec.feature "Request by family", type: :feature do
       expect(page).to have_text("Upload a letter of consent")
       # Letter of Consent
       attach_file("request-form-letter-of-consent-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload a letter of consent")
       click_button "Continue"
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Upload a letter of consent")

--- a/spec/features/request_by_family_spec.rb
+++ b/spec/features/request_by_family_spec.rb
@@ -88,4 +88,50 @@ RSpec.feature "Request by family", type: :feature do
     # Form sent
     expect(page).to have_text("Request sent")
   end
+
+  describe "User uploads invalid files and cannot progress" do
+    before do
+      start_application
+      fill_in_request_type_and_initial_personal_details(type: "Relative, friend or something else")
+    end
+
+    scenario "when requester photo id" do
+      # Upload ID
+      attach_file("request-form-requester-photo-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your photo ID")
+      click_button "Continue"
+      expect(page).not_to have_text("Upload your proof of address")
+      expect(page).to have_text("Upload your photo ID")
+    end
+
+    scenario "when requester address" do
+      # Upload ID
+      attach_file("request-form-requester-photo-field", "spec/fixtures/files/file.jpg")
+      click_button "Continue"
+      expect(page).to have_text("Upload your proof of address")
+      # Upload address
+      attach_file("request-form-requester-proof-of-address-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your proof of address")
+    end
+
+    scenario "when requester letter of consent" do
+      # Upload ID
+      attach_file("request-form-requester-photo-field", "spec/fixtures/files/file.jpg")
+      click_button "Continue"
+      expect(page).to have_text("Upload your proof of address")
+      # Upload address
+      attach_file("request-form-requester-proof-of-address-field", "spec/fixtures/files/file.jpg")
+      click_button "Continue"
+      expect(page).to have_text("Upload a letter of consent")
+      # Letter of Consent
+      attach_file("request-form-letter-of-consent-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload a letter of consent")
+    end
+  end
 end

--- a/spec/features/request_by_solicitor_spec.rb
+++ b/spec/features/request_by_solicitor_spec.rb
@@ -84,6 +84,9 @@ RSpec.feature "Request by solicitor", type: :feature do
       click_button "Continue"
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Upload a letter of consent")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload a letter of consent")
     end
   end
 end

--- a/spec/features/request_by_solicitor_spec.rb
+++ b/spec/features/request_by_solicitor_spec.rb
@@ -71,4 +71,19 @@ RSpec.feature "Request by solicitor", type: :feature do
     # Form sent
     expect(page).to have_text("Request sent")
   end
+
+  describe "User uploads invalid files and cannot progress" do
+    before do
+      start_application
+      fill_in_request_type_and_initial_personal_details(type: "Legal representative")
+    end
+
+    scenario "when requester letter of consent" do
+      # Letter of Consent
+      attach_file("request-form-letter-of-consent-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload a letter of consent")
+    end
+  end
 end

--- a/spec/features/request_for_self_spec.rb
+++ b/spec/features/request_for_self_spec.rb
@@ -68,4 +68,34 @@ RSpec.feature "Request for self", type: :feature do
     # Form sent
     expect(page).to have_text("Request sent")
   end
+
+  describe "User uploads invalid files and cannot progress" do
+    before do
+      start_application
+      fill_in_request_type_and_initial_personal_details(type: "My own")
+    end
+
+    scenario "when subject photo id" do
+      # Upload ID
+      attach_file("request-form-subject-photo-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your photo ID")
+      click_button "Continue"
+      expect(page).not_to have_text("Upload your proof of address")
+      expect(page).to have_text("Upload your photo ID")
+    end
+
+    scenario "when subject address" do
+      # Upload ID
+      attach_file("request-form-subject-photo-field", "spec/fixtures/files/file.jpg")
+      click_button "Continue"
+      expect(page).to have_text("Upload your proof of address")
+      # Upload address
+      attach_file("request-form-subject-proof-of-address-field", "spec/fixtures/files/invalid_image.txt")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your proof of address")
+    end
+  end
 end

--- a/spec/features/request_for_self_spec.rb
+++ b/spec/features/request_for_self_spec.rb
@@ -96,6 +96,9 @@ RSpec.feature "Request for self", type: :feature do
       click_button "Continue"
       expect(page).to have_text("There is a problem")
       expect(page).to have_text("Upload your proof of address")
+      click_button "Continue"
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Upload your proof of address")
     end
   end
 end

--- a/spec/support/flow_helpers.rb
+++ b/spec/support/flow_helpers.rb
@@ -1,0 +1,61 @@
+def start_application
+  visit "/"
+  click_link "Start now"
+end
+
+def fill_in_request_type_and_initial_personal_details(type: "My own")
+  case type
+  when "My own"
+    # Subject
+    choose "My own"
+    click_button "Continue"
+
+    # Your details
+    fill_in("Full name", with: "John")
+    click_button "Continue"
+
+    # Date of birth
+    fill_in("Day", with: "1")
+    fill_in("Month", with: "1")
+    fill_in("Year", with: "2000")
+    click_button "Continue"
+  when "Relative, friend or something else"
+    non_self_request_page_flow
+
+    # Relationship
+    choose type
+    click_button "Continue"
+
+    # Your details
+    fill_in("Your full name", with: "Mary")
+    click_button "Continue"
+  when "Legal representative"
+    non_self_request_page_flow
+
+    # Relationship
+    choose type
+    click_button "Continue"
+
+    # Your details
+    fill_in("Name of your organisation", with: "Solicitor Name")
+    click_button "Continue"
+  else
+    raise "Unknown type: #{type}"
+  end
+end
+
+def non_self_request_page_flow
+  # Subject
+  choose "Someone else's"
+  click_button "Continue"
+
+  # Your details
+  fill_in("Full name", with: "John")
+  click_button "Continue"
+
+  # Date of birth
+  fill_in("Day", with: "1")
+  fill_in("Month", with: "1")
+  fill_in("Year", with: "2000")
+  click_button "Continue"
+end


### PR DESCRIPTION
An issue with how the attachments are saved was causing invalid files to create entries into Attachments. This meant that validation was skipped and the user could bypass the file upload after triggering validation, and seemingly upload an invalid file.

This issue could possibly do with a refactor so that the attachments are not saved before the form validation happens. However for now I think it is sensible to delete the file once form validation has been triggered. We should potentially ticket up a refactor for the backlog. 

These methods in InformationRequest are potentially a bit of an issue:
```
def letter_of_consent=(file)
    file_object = Attachment.create!(file:, key: "letter_of_consent")
    self.letter_of_consent_id = file_object.id
  end

  def requester_photo=(file)
    file_object = Attachment.create!(file:, key: "requester_photo")
    self.requester_photo_id = file_object.id
  end

  def requester_proof_of_address=(file)
    file_object = Attachment.create!(file:, key: "requester_proof_of_address")
    self.requester_proof_of_address_id = file_object.id
  end

  def subject_photo=(file)
    file_object = Attachment.create!(file:, key: "subject_photo")
    self.subject_photo_id = file_object.id
  end

  def subject_proof_of_address=(file)
    file_object = Attachment.create!(file:, key: "subject_proof_of_address")
    self.subject_proof_of_address_id = file_object.id
  end
```