### PR TITLE
bump rack & rack-session gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,10 +457,10 @@ GEM
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-proxy (0.7.7)
       rack
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)


### PR DESCRIPTION
Gem updates
- bump rack from 3.2.5 to 3.2.6
- bump rack-session from 2.1.1 to 2.1.2