### PR TITLE
CDPTKAN-881 Set homepage tab title.

### DIFF
--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -1,3 +1,5 @@
+<% title t(".page_title") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Request personal information from the Ministry of Justice</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,8 @@ en:
       sar_research_email_html: "<a href='mailto:sar.research@digital.justice.gov.uk.'>sar.research@digital.justice.gov.uk.</a>"
     cookie_consent:
       page_title: Cookies
+    homepage:
+      page_title: Start
     privacy:
       page_title: Privacy notice
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
     cookie_consent:
       page_title: Cookies
     homepage:
-      page_title: Start
+      page_title: Request personal information
     privacy:
       page_title: Privacy notice
 


### PR DESCRIPTION
### Description
The homepage browser tab currently displays the environment URL.  This needs to be changed to 'Request personal information'. 

**Before**

<img width="358" height="91" alt="original-tab" src="https://github.com/user-attachments/assets/b463f0f3-a968-499b-a01c-814fd54d318f" />

**After**

<img width="358" height="91" alt="updated-tab" src="https://github.com/user-attachments/assets/841ceb89-d00e-48cb-9131-82533a2e764e" />

### Jira ticket
https://dsdmoj.atlassian.net/browse/CDPTKAN-881