### PR TITLE
CDPTKAN-881 Update homepage tab title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template govuk-template--rebranded" lang="en">
   <head>
-    <title lang="en"><%= yield(:page_title) %></title>
+    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
 
     <%= csrf_meta_tags %>
 

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -1,5 +1,3 @@
-<% title t(".page_title") %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Request personal information from the Ministry of Justice</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,8 +221,6 @@ en:
       sar_research_email_html: "<a href='mailto:sar.research@digital.justice.gov.uk.'>sar.research@digital.justice.gov.uk.</a>"
     cookie_consent:
       page_title: Cookies
-    homepage:
-      page_title: Request personal information
     privacy:
       page_title: Privacy notice
 


### PR DESCRIPTION
### Description
The homepage browser tab title was displaying 'Request personal information - Request personal information'.  Updated the template to check for present of title text and display the service name if none present.  The browser tab should now only display  'Request personal information' when the homepage renders.  All other page tabs should follow the format _[TITLE] - [SERVICE NAME]_

### Jira ticket
https://dsdmoj.atlassian.net/browse/CDPTKAN-881