### PR TITLE
CDPTKAN-1048 Remove ratonvirus dependency and replace with clamav-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby file: ".ruby-version"
 
 gem "aws-sdk-s3", require: false
+gem "clamav-client"
 gem "daemons"
 gem "delayed_job_active_record"
 gem "govuk_app_config", ">= 9.15.4"
@@ -13,8 +14,6 @@ gem "mail-notify"
 gem "pg"
 gem "puma", ">= 5.0"
 gem "rails"
-gem "ratonvirus"
-gem "ratonvirus-clamby"
 gem "sentry-rails", ">= 5.22.2"
 gem "sentry-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.1)
-    clamby (1.6.11)
+    clamav-client (3.2.0)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
     crass (1.0.6)
@@ -504,11 +504,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    ratonvirus (0.5.0)
-      activesupport (~> 7.0)
-    ratonvirus-clamby (0.5.0)
-      clamby (~> 1.6)
-      ratonvirus (~> 0.5.0)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -644,6 +639,7 @@ DEPENDENCIES
   binding_of_caller
   brakeman
   capybara
+  clamav-client
   daemons
   dartsass-rails (~> 0.5.1)
   database_cleaner-active_record
@@ -660,8 +656,6 @@ DEPENDENCIES
   puma (>= 5.0)
   rails
   rails-controller-testing
-  ratonvirus
-  ratonvirus-clamby
   rspec-rails (>= 7.1.1)
   rubocop-govuk
   sentry-rails (>= 5.22.2)

--- a/app/validators/anti_virus_validator.rb
+++ b/app/validators/anti_virus_validator.rb
@@ -5,7 +5,7 @@ class AntiVirusValidator < ActiveModel::EachValidator
     path = value.path
     return unless path.present? && File.exist?(path)
 
-    client = build_client
+    client = clamav_client
     response = client.execute(ClamAV::Commands::ScanCommand.new(path)).first
 
     case response
@@ -14,13 +14,21 @@ class AntiVirusValidator < ActiveModel::EachValidator
     when ClamAV::ErrorResponse
       raise RequestsController::ClientProcessingError
     end
-  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::ENOENT
+  rescue SocketError,
+         IOError,
+         Timeout::Error,
+         Errno::ECONNREFUSED,
+         Errno::ECONNRESET,
+         Errno::EHOSTUNREACH,
+         Errno::ENETUNREACH,
+         Errno::ETIMEDOUT,
+         Errno::ENOENT
     raise RequestsController::ClientProcessingError
   end
 
 private
 
-  def build_client
+  def clamav_client
     ClamAV::Client.new(
       ClamAV::Connection.new(
         socket: ::TCPSocket.new(

--- a/app/validators/anti_virus_validator.rb
+++ b/app/validators/anti_virus_validator.rb
@@ -2,20 +2,33 @@ class AntiVirusValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.nil?
 
-    storage = Ratonvirus.storage
-    return unless storage.accept?(value.path)
+    path = value.path
+    return unless path.present? && File.exist?(path)
 
-    scanner = Ratonvirus.scanner
-    return unless scanner.available?
+    client = build_client
+    response = client.execute(ClamAV::Commands::ScanCommand.new(path)).first
 
-    return unless scanner.virus?(value.path)
-
-    if scanner.errors.any?
-      scanner.errors.each do |err|
-        raise RequestsController::ClientProcessingError if err == :antivirus_client_error
-
-        record.errors.add attribute, err
-      end
+    case response
+    when ClamAV::VirusResponse
+      record.errors.add(attribute, :antivirus_virus_detected)
+    when ClamAV::ErrorResponse
+      raise RequestsController::ClientProcessingError
     end
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::ENOENT
+    raise RequestsController::ClientProcessingError
+  end
+
+private
+
+  def build_client
+    ClamAV::Client.new(
+      ClamAV::Connection.new(
+        socket: ::TCPSocket.new(
+          ENV.fetch("CLAMD_TCP_HOST", "request-personal-information-clamav-service"),
+          ENV.fetch("CLAMD_TCP_PORT", 3310).to_i,
+        ),
+        wrapper: ClamAV::Wrappers::NewLineWrapper.new,
+      ),
+    )
   end
 end

--- a/config/initializers/ratonvirus.rb
+++ b/config/initializers/ratonvirus.rb
@@ -1,4 +1,0 @@
-Ratonvirus.configure do |config|
-  config.scanner = Rails.env.local? ? :eicar : :clamby
-  config.storage = :filepath
-end

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
-        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+        let(:virus_file) { fixture_file_upload("file.jpg", "image/jpeg") }
 
         before do
           clamav_client = instance_double(ClamAV::Client)
@@ -120,7 +120,7 @@ RSpec.describe "Requester", type: :request do
         end
 
         it "renders page with error message" do
-          patch "/request", params: { request_form: { requester_photo: eicar_data } }
+          patch "/request", params: { request_form: { requester_photo: virus_file } }
           expect(response).to render_template(:edit)
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("File contains a virus")
@@ -214,7 +214,7 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
-        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+        let(:virus_file) { fixture_file_upload("file.jpg", "image/jpeg") }
 
         before do
           clamav_client = instance_double(ClamAV::Client)
@@ -224,7 +224,7 @@ RSpec.describe "Requester", type: :request do
         end
 
         it "renders page with error message" do
-          patch "/request", params: { request_form: { requester_proof_of_address: eicar_data } }
+          patch "/request", params: { request_form: { requester_proof_of_address: virus_file } }
           expect(response).to render_template(:edit)
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("File contains a virus")
@@ -273,7 +273,7 @@ RSpec.describe "Requester", type: :request do
 
     context "when session in progress" do
       let(:valid_data) { fixture_file_upload("file.jpg", "image/jpeg") }
-      let(:eicar_data) { fixture_file_upload("eicar.jpg", "image/jpeg") }
+      let(:virus_file) { fixture_file_upload("eicar.jpg", "image/jpeg") }
       let(:invalid_data) { nil }
 
       before do
@@ -288,7 +288,7 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
-        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+        let(:virus_file) { fixture_file_upload("file.jpg", "image/jpeg") }
 
         before do
           clamav_client = instance_double(ClamAV::Client)
@@ -298,7 +298,7 @@ RSpec.describe "Requester", type: :request do
         end
 
         it "renders page with error message" do
-          patch "/request", params: { request_form: { letter_of_consent: eicar_data } }
+          patch "/request", params: { request_form: { letter_of_consent: virus_file } }
           expect(response).to render_template(:edit)
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("File contains a virus")

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting form with invalid data" do
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { organisation_name: invalid_data } }
           expect(response).to render_template(:edit)
@@ -103,6 +110,15 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
+        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { requester_photo: eicar_data } }
           expect(response).to render_template(:edit)
@@ -113,7 +129,10 @@ RSpec.describe "Requester", type: :request do
 
       context "when Clam AV service is unavailable" do
         it "shows internal error page" do
-          allow(Ratonvirus.scanner).to receive_messages(available?: true, virus?: true, errors: [:antivirus_client_error])
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_raise(Errno::ECONNREFUSED)
           patch "/request", params: { request_form: { requester_photo: valid_data } }
           expect(response).to render_template("errors/internal_error")
           expect(response.body).to include("Sorry, there is a problem with this service")
@@ -195,6 +214,15 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
+        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { requester_proof_of_address: eicar_data } }
           expect(response).to render_template(:edit)
@@ -260,6 +288,15 @@ RSpec.describe "Requester", type: :request do
       end
 
       context "when submitting file with virus" do
+        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { letter_of_consent: eicar_data } }
           expect(response).to render_template(:edit)

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -256,6 +256,15 @@ RSpec.describe "Subject", type: :request do
       end
 
       context "when submitting file with virus" do
+        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { subject_photo: eicar_data } }
           expect(response).to render_template(:edit)
@@ -344,6 +353,15 @@ RSpec.describe "Subject", type: :request do
       end
 
       context "when submitting file with virus" do
+        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+
+        before do
+          clamav_client = instance_double(ClamAV::Client)
+          allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+          allow(clamav_client).to receive(:execute)
+                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        end
+
         it "renders page with error message" do
           patch "/request", params: { request_form: { subject_proof_of_address: eicar_data } }
           expect(response).to render_template(:edit)

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "Subject", type: :request do
       end
 
       context "when submitting file with virus" do
-        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+        let(:virus_file) { fixture_file_upload("file.jpg", "image/jpeg") }
 
         before do
           clamav_client = instance_double(ClamAV::Client)
@@ -266,7 +266,7 @@ RSpec.describe "Subject", type: :request do
         end
 
         it "renders page with error message" do
-          patch "/request", params: { request_form: { subject_photo: eicar_data } }
+          patch "/request", params: { request_form: { subject_photo: virus_file } }
           expect(response).to render_template(:edit)
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("File contains a virus")
@@ -353,7 +353,7 @@ RSpec.describe "Subject", type: :request do
       end
 
       context "when submitting file with virus" do
-        let(:eicar_data) { fixture_file_upload("file.jpg", "image/jpeg") }
+        let(:virus_file) { fixture_file_upload("file.jpg", "image/jpeg") }
 
         before do
           clamav_client = instance_double(ClamAV::Client)
@@ -363,7 +363,7 @@ RSpec.describe "Subject", type: :request do
         end
 
         it "renders page with error message" do
-          patch "/request", params: { request_form: { subject_proof_of_address: eicar_data } }
+          patch "/request", params: { request_form: { subject_proof_of_address: virus_file } }
           expect(response).to render_template(:edit)
           expect(response.body).to include("There is a problem")
           expect(response.body).to include("File contains a virus")

--- a/spec/support/clamav.rb
+++ b/spec/support/clamav.rb
@@ -1,0 +1,14 @@
+# spec/support/clamav.rb
+RSpec.configure do |config|
+  config.before do
+    tcp_socket = instance_double(TCPSocket)
+    allow(TCPSocket).to receive(:new).and_return(tcp_socket)
+    allow(tcp_socket).to receive(:write)
+    allow(tcp_socket).to receive(:read)
+
+    clamav_client = instance_double(ClamAV::Client)
+    allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+    allow(clamav_client).to receive(:execute)
+                              .and_return([ClamAV::SuccessResponse.new("/path/to/file")])
+  end
+end

--- a/spec/support/shared_validation.rb
+++ b/spec/support/shared_validation.rb
@@ -62,7 +62,11 @@ RSpec.shared_examples("file upload") do |attribute|
       subject(:form_object) { described_class.new }
 
       before do
-        form_object.send("#{attribute}=", fixture_file_upload("eicar.jpg", "image/jpeg"))
+        clamav_client = instance_double(ClamAV::Client)
+        allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+        allow(clamav_client).to receive(:execute)
+                                  .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+        form_object.send("#{attribute}=", fixture_file_upload("file.jpg", "image/jpeg"))
       end
 
       it "is not valid" do
@@ -72,6 +76,22 @@ RSpec.shared_examples("file upload") do |attribute|
       it "is has the expected error message" do
         form_object.valid?
         expect(form_object.errors.messages[attribute].first).to eq("File contains a virus")
+      end
+    end
+
+    context "when ClamAV returns an error response" do
+      subject(:form_object) { described_class.new }
+
+      before do
+        clamav_client = instance_double(ClamAV::Client)
+        allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
+        allow(clamav_client).to receive(:execute)
+                                  .and_return([ClamAV::ErrorResponse.new("error")])
+        form_object.send("#{attribute}=", fixture_file_upload("file.jpg", "image/jpeg"))
+      end
+
+      it "raises ClientProcessingError" do
+        expect { form_object.valid? }.to raise_error(RequestsController::ClientProcessingError)
       end
     end
 


### PR DESCRIPTION
Remove ratonvirus dependency and replace with clamav-client

**Why**
`ratonvirus` pins `activesupport ~> 7.0` which is incompatible with Rails 8. Rather than forking and patching the gem, we replace it with `clamav-client` which has no Rails version constraints.

**What changed**
**Dependencies**

- Removed ratonvirus and ratonvirus-clamby gems
- Added clamav-client gem

**Validator**

- Rewrote AntiVirusValidator to use clamav-client directly, connecting to ClamAV via TCP using CLAMD_TCP_HOST and CLAMD_TCP_PORT env vars (falling back to the existing service hostname)
Virus detected → adds antivirus_virus_detected error to the record
ClamAV error or connection failure → raises RequestsController::ClientProcessingError

**Tests**
- Added spec/support/clamav.rb to stub ClamAV::Client and TCPSocket globally, preventing tests from attempting real connections
- Updated virus test contexts to override the stub with a VirusResponse
- Updated spec/support/shared_validation.rb to stub ClamAV in virus-related contexts and added coverage for the ErrorResponse path
- Removed stale Ratonvirus references from request specs

