### PR TITLE
CDPTKAN-1048 Fix ClamAV antivirus scanning in containerised environments

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -158,6 +158,7 @@ private
   def request_params
     params.require(:request_form).permit(
       :return_to,
+      :default,
       :subject,
       :full_name,
       :other_names,

--- a/app/validators/anti_virus_validator.rb
+++ b/app/validators/anti_virus_validator.rb
@@ -6,7 +6,7 @@ class AntiVirusValidator < ActiveModel::EachValidator
     return unless path.present? && File.exist?(path)
 
     client = clamav_client
-    response = client.execute(ClamAV::Commands::ScanCommand.new(path)).first
+    response = File.open(path) { |f| client.execute(ClamAV::Commands::InstreamCommand.new(f)) }
 
     case response
     when ClamAV::VirusResponse

--- a/config/kubernetes/development/config_map.yml
+++ b/config/kubernetes/development/config_map.yml
@@ -9,3 +9,5 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   API_URL: "https://qa.track-a-query.service.justice.gov.uk/api/rpi/"
   API_SCHEMA: "2"
+  CLAMD_TCP_HOST: request-personal-information-clamav-service
+  CLAMD_TCP_PORT: "3310"

--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -9,3 +9,5 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   API_URL: "https://track-a-query.service.justice.gov.uk/api/rpi/"
   API_SCHEMA: "2"
+  CLAMD_TCP_HOST: request-personal-information-clamav-service
+  CLAMD_TCP_PORT: "3310"

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -9,3 +9,5 @@ data:
   RAILS_SERVE_STATIC_FILES: enabled
   API_URL: "https://qa.track-a-query.service.justice.gov.uk/api/rpi/"
   API_SCHEMA: "2"
+  CLAMD_TCP_HOST: request-personal-information-clamav-service
+  CLAMD_TCP_PORT: "3310"

--- a/spec/requests/requester_spec.rb
+++ b/spec/requests/requester_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Requester", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do
@@ -116,7 +116,7 @@ RSpec.describe "Requester", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do
@@ -220,7 +220,7 @@ RSpec.describe "Requester", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do
@@ -294,7 +294,7 @@ RSpec.describe "Requester", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do

--- a/spec/requests/subject_spec.rb
+++ b/spec/requests/subject_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Subject", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do
@@ -359,7 +359,7 @@ RSpec.describe "Subject", type: :request do
           clamav_client = instance_double(ClamAV::Client)
           allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
           allow(clamav_client).to receive(:execute)
-                                    .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                    .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         end
 
         it "renders page with error message" do

--- a/spec/support/clamav.rb
+++ b/spec/support/clamav.rb
@@ -9,6 +9,6 @@ RSpec.configure do |config|
     clamav_client = instance_double(ClamAV::Client)
     allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
     allow(clamav_client).to receive(:execute)
-                              .and_return([ClamAV::SuccessResponse.new("/path/to/file")])
+                              .and_return(ClamAV::SuccessResponse.new("/path/to/file"))
   end
 end

--- a/spec/support/shared_validation.rb
+++ b/spec/support/shared_validation.rb
@@ -65,7 +65,7 @@ RSpec.shared_examples("file upload") do |attribute|
         clamav_client = instance_double(ClamAV::Client)
         allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
         allow(clamav_client).to receive(:execute)
-                                  .and_return([ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature")])
+                                  .and_return(ClamAV::VirusResponse.new("/path/to/file", "Eicar-Test-Signature"))
         form_object.send("#{attribute}=", fixture_file_upload("file.jpg", "image/jpeg"))
       end
 
@@ -86,7 +86,7 @@ RSpec.shared_examples("file upload") do |attribute|
         clamav_client = instance_double(ClamAV::Client)
         allow(ClamAV::Client).to receive(:new).and_return(clamav_client)
         allow(clamav_client).to receive(:execute)
-                                  .and_return([ClamAV::ErrorResponse.new("error")])
+                                  .and_return(ClamAV::ErrorResponse.new("error"))
         form_object.send("#{attribute}=", fixture_file_upload("file.jpg", "image/jpeg"))
       end
 


### PR DESCRIPTION


The previous implementation used `ScanCommand` which tells the clamd daemon to scan a file by path. This failed in Kubernetes because clamd runs in a separate container and cannot access temp file paths on the Rails app container, causing `ClamAV::ErrorResponse` and surfacing as an internal error to users.

**Changes:**
- Switch `AntiVirusValidator` from `ScanCommand` to `InstreamCommand`, which streams file bytes over the TCP socket so clamd never needs filesystem access
- Add `:default` to permitted parameters in `RequestsController#request_params` to resolve unpermitted parameter warnings (the `default` hidden field exists in multiple form views and is declared as an `attr_accessor` on form models)
- Add `CLAMD_TCP_HOST` and `CLAMD_TCP_PORT` explicitly to all three Kubernetes environment config maps
- Update all ClamAV test stubs from array returns to single response objects to match the `InstreamCommand` return type
